### PR TITLE
Add fix to allow multiple /'s in image name

### DIFF
--- a/controllers/webspherelibertyapplication_controller.go
+++ b/controllers/webspherelibertyapplication_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	networkingv1 "k8s.io/api/networking/v1"
 
@@ -200,7 +201,7 @@ func (r *ReconcileWebSphereLiberty) Reconcile(ctx context.Context, request ctrl.
 				if image.DockerImageReference != "" {
 					instance.Status.ImageReference = image.DockerImageReference
 				}
-			} else if err != nil && !kerrors.IsNotFound(err) && !kerrors.IsForbidden(err) {
+			} else if err != nil && !kerrors.IsNotFound(err) && !kerrors.IsForbidden(err) && !strings.Contains(isTagName, "/") {
 				return r.ManageError(err, common.StatusConditionTypeReconciled, instance)
 			}
 		}


### PR DESCRIPTION
- Ported fix to allow multiple /'s in the application image name.

Signed-off-by: Jason Yong <jason_yong@uk.ibm.com>