### PR TITLE
Allow user/group to be specified using ARG

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
+ARG USER_ID=65532
+ARG GROUP_ID=65532
+
 LABEL vendor="WebSphere Liberty" \
       name="WebSphere Liberty Operator" \
       version="1.0.0" \
@@ -33,6 +36,6 @@ COPY LICENSE /licenses/
 WORKDIR /
 COPY --from=builder /workspace/manager .
 
-USER 65532:65532
+USER ${USER_ID}:${GROUP_ID}
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
This is part of meeting the requirements of
WASdev/websphere-liberty-operator-certification#61