### PR TITLE
Bundle and catalog should reference production (icr.io/cpopen) image

### DIFF
--- a/.one-pipeline.yaml
+++ b/.one-pipeline.yaml
@@ -105,8 +105,6 @@ containerize:
     export REDHAT_BASE_IMAGE=$(get_env redhat-base-image)
     export REDHAT_REGISTRY=$(get_env redhat-registry)
     export OPM_VERSION=$(get_env opm-version)
-
-    echo "PIPELINE_PRODUCTION_IMAGE=$PIPELINE_PRODUCTION_IMAGE"
     
     # Build amd64 image
     make build-pipeline-releases
@@ -120,7 +118,6 @@ containerize:
 
     # Build bundle image
     make setup
-    echo "PIPELINE_PRODUCTION_IMAGE=$PIPELINE_PRODUCTION_IMAGE"
     make bundle-pipeline
 
     # Build catalog image

--- a/.one-pipeline.yaml
+++ b/.one-pipeline.yaml
@@ -95,6 +95,7 @@ containerize:
     export PIPELINE_USERNAME=$(get_env ibmcloud-api-user)
     export PIPELINE_PASSWORD=$(get_env ibmcloud-api-key-staging)
     export PIPELINE_REGISTRY=$(get_env pipeline-registry)
+    export PIPELINE_PRODUCTION_IMAGE=$(get_env pipeline-production-image)
     export PIPELINE_OPERATOR_IMAGE=$(get_env pipeline-operator-image)
     export RELEASE_TARGET=$(get_env branch)
     export DOCKER_USERNAME=$(get_env docker-username)

--- a/.one-pipeline.yaml
+++ b/.one-pipeline.yaml
@@ -105,6 +105,8 @@ containerize:
     export REDHAT_BASE_IMAGE=$(get_env redhat-base-image)
     export REDHAT_REGISTRY=$(get_env redhat-registry)
     export OPM_VERSION=$(get_env opm-version)
+
+    echo "PIPELINE_PRODUCTION_IMAGE=$PIPELINE_PRODUCTION_IMAGE"
     
     # Build amd64 image
     make build-pipeline-releases
@@ -118,6 +120,7 @@ containerize:
 
     # Build bundle image
     make setup
+    echo "PIPELINE_PRODUCTION_IMAGE=$PIPELINE_PRODUCTION_IMAGE"
     make bundle-pipeline
 
     # Build catalog image

--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,7 @@ bundle-pipeline:
 	./scripts/bundle-release.sh -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}" --registry "${PIPELINE_REGISTRY}" --prod-image "${PIPELINE_PRODUCTION_IMAGE}" --image "${PIPELINE_REGISTRY}/${PIPELINE_OPERATOR_IMAGE}" --release "${RELEASE_TARGET}"
 
 catalog-pipeline-build: opm ## Build a catalog image.
-	./scripts/catalog-build.sh -n "v${OPM_VERSION}" -b "${REDHAT_BASE_IMAGE}" -o "${OPM}" --container-tool "docker" -i "${PIPELINE_REGISTRY}/${PIPELINE_OPERATOR_IMAGE}-bundle:${RELEASE_TARGET}" -a "${PIPELINE_REGISTRY}/${PIPELINE_OPERATOR_IMAGE}-catalog:${RELEASE_TARGET}" -t "${PWD}/operator-build"
+	./scripts/catalog-build.sh -n "v${OPM_VERSION}" -b "${REDHAT_BASE_IMAGE}" -o "${OPM}" --container-tool "docker" -i "${PIPELINE_REGISTRY}/${PIPELINE_OPERATOR_IMAGE}-bundle:${RELEASE_TARGET}" -p "${PIPELINE_PRODUCTION_IMAGE}-bundle" -a "${PIPELINE_REGISTRY}/${PIPELINE_OPERATOR_IMAGE}-catalog:${RELEASE_TARGET}" -t "${PWD}/operator-build"
 
 catalog-pipeline-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG="${PIPELINE_REGISTRY}/${PIPELINE_OPERATOR_IMAGE}-catalog:${RELEASE_TARGET}"

--- a/Makefile
+++ b/Makefile
@@ -253,7 +253,7 @@ build-pipeline-manifest: setup-manifest
 	./scripts/build-manifest.sh -u "${PIPELINE_USERNAME}" -p "${PIPELINE_PASSWORD}" --registry "${PIPELINE_REGISTRY}" --image "${PIPELINE_REGISTRY}/${PIPELINE_OPERATOR_IMAGE}"	--target "${RELEASE_TARGET}"
 
 bundle-pipeline:
-	./scripts/bundle-release.sh -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}" --registry "${PIPELINE_REGISTRY}" --image "${PIPELINE_REGISTRY}/${PIPELINE_OPERATOR_IMAGE}" --release "${RELEASE_TARGET}"
+	./scripts/bundle-release.sh -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}" --registry "${PIPELINE_REGISTRY}" --prod-image "${PIPELINE_PRODUCTION_IMAGE}" --image "${PIPELINE_REGISTRY}/${PIPELINE_OPERATOR_IMAGE}" --release "${RELEASE_TARGET}"
 
 catalog-pipeline-build: opm ## Build a catalog image.
 	./scripts/catalog-build.sh -n "v${OPM_VERSION}" -b "${REDHAT_BASE_IMAGE}" -o "${OPM}" --container-tool "docker" -i "${PIPELINE_REGISTRY}/${PIPELINE_OPERATOR_IMAGE}-bundle:${RELEASE_TARGET}" -a "${PIPELINE_REGISTRY}/${PIPELINE_OPERATOR_IMAGE}-catalog:${RELEASE_TARGET}" -t "${PWD}/operator-build"

--- a/scripts/bundle-release.sh
+++ b/scripts/bundle-release.sh
@@ -55,7 +55,7 @@ main() {
     readonly release_tag="${RELEASE}"
   fi
 
-  readonly full_image="${IMAGE}:${release_tag}-${arch}"
+  readonly full_image="${PROD_IMAGE}:${release_tag}-${arch}"
   readonly bundle_image="${IMAGE}-bundle:${release_tag}"
 
   ## login to docker
@@ -103,7 +103,11 @@ parse_args() {
     --registry)
       shift
       readonly REGISTRY="${1}"
-      ;;        
+      ;;
+    --prod-image)
+      shift
+      readonly PROD_IMAGE="${1}"
+      ;;    
     --image)
       shift
       readonly IMAGE="${1}"

--- a/scripts/bundle-release.sh
+++ b/scripts/bundle-release.sh
@@ -55,7 +55,8 @@ main() {
     readonly release_tag="${RELEASE}"
   fi
 
-  readonly full_image="${PROD_IMAGE}:${release_tag}-${arch}"
+  readonly digest="$(skopeo inspect docker://$IMAGE:${release_tag}-${arch} | grep Digest | grep -o 'sha[^\"]*')"
+  readonly full_image="${PROD_IMAGE}:${digest}"
   readonly bundle_image="${IMAGE}-bundle:${release_tag}"
 
   ## login to docker

--- a/scripts/bundle-release.sh
+++ b/scripts/bundle-release.sh
@@ -62,7 +62,7 @@ main() {
   fi
 
   readonly digest="$(skopeo inspect docker://$IMAGE:${release_tag}-${arch} | grep Digest | grep -o 'sha[^\"]*')"
-  readonly full_image="${PROD_IMAGE}:${digest}"
+  readonly full_image="${PROD_IMAGE}@${digest}"
   readonly bundle_image="${IMAGE}-bundle:${release_tag}"
 
   ## login to docker

--- a/scripts/bundle-release.sh
+++ b/scripts/bundle-release.sh
@@ -12,13 +12,19 @@
 
 set -Eeo pipefail
 
-readonly usage="Usage: bundle-release.sh -u <docker-username> -p <docker-password> --image repository/image --release <release> [--skip-push]"
+readonly usage="Usage: bundle-release.sh -u <docker-username> -p <docker-password> --image repository/image --prod-image prod-repository/image --release <release> [--skip-push]"
 
 main() {
   parse_args "$@"
 
   if [[ -z "${IMAGE}" ]]; then
     echo "****** Missing target image for operator build, see usage"
+    echo "${usage}"
+    exit 1
+  fi
+
+  if [[ -z "${PROD_IMAGE}" ]]; then
+    echo "****** Missing production image reference for bundle, see usage"
     echo "${usage}"
     exit 1
   fi

--- a/scripts/catalog-build.sh
+++ b/scripts/catalog-build.sh
@@ -15,6 +15,7 @@ usage() {
     echo "  -b, --base-image         [REQUIRED] The base image that the index will be built upon (e.g. registry.redhat.io/openshift4/ose-operator-registry)"
     echo "  -t, --output             [REQUIRED] The location where the database should be output"
     echo "  -i, --image-name         [REQUIRED] The bundle image name"
+    echo "  -p, --prod-image         [REQUIRED] The name of the production image the bundle should point to"
     echo "  -a, --catalog-image-name [REQUIRED] the catalog image name"
     echo "  -c, --container-tool     Tool to build image [docker, podman] (default 'docker')"
     echo "  -o, --opm-tool           Name of the opm tool (default 'opm')"

--- a/scripts/catalog-build.sh
+++ b/scripts/catalog-build.sh
@@ -56,6 +56,10 @@ function parse_arguments() {
             shift
             BUNDLE_IMAGE=$1
             ;;
+        -p | --prod-image)
+            shift
+            PROD_IMAGE=$1
+            ;;
         -a | --catalog-image-name)
             shift
             CATALOG_IMAGE=$1
@@ -80,10 +84,10 @@ function create_empty_db() {
 }
 
 function add_to_db(){
-    local img=$1
-    local digest="$(skopeo inspect docker://$img | grep Digest | grep -o 'sha[^\"]*')"
-    local taglessImg="$(echo $img | cut -d ':' -f 1)"
-    local img_digest="${taglessImg}@${digest}"
+    local stg_img=$1
+    local prod_img=$2
+    local digest="$(skopeo inspect docker://$stg_img | grep Digest | grep -o 'sha[^\"]*')"
+    local img_digest="${prod_img}@${digest}"
     echo "------------ adding bundle image ${img_digest} to ${TMP_DIR}/bundles.db ------------"
     "${OPM_TOOL}" registry add -b "${img_digest}" -d "${TMP_DIR}/bundles.db" -c "${CONTAINER_TOOL}" --permissive
 }
@@ -107,7 +111,7 @@ function build_catalog() {
 
     create_empty_db
     ## for now, add the current build's image.  In future, we need to loop through all versions and add each releases bundle image
-    add_to_db "${BUNDLE_IMAGE}"
+    add_to_db "${BUNDLE_IMAGE}" "${PROD_IMAGE}"
 
     # Copy bundles.db local prior to building the image
     cp "${TMP_DIR}/bundles.db" .


### PR DESCRIPTION
for https://github.com/WASdev/websphere-liberty-operator-certification/issues/52

This PR fixes two issues mentioned by @leochr [here](https://github.ibm.com/IBMCloudPak4Apps/wshe-OnePipeline/issues/72#issuecomment-41964590): 

1. Both the bundle referred to the operator image and the catalog referred to the bundle in staging (cp.stg.icr.io/cp), rather than in production (icr.io/cpopen). I fixed this by taking an additional parameter in the relevant scripts (`--prod-image`) which will point to what the production image _will be_ (i.e., icr.io/cpopen/websphere-liberty-operator) which can be set via the pipeline parameter `pipeline-production-image`. This seemed like the best route since "generating" the production value through parsing strings feels hacky and prone to error, and hard-coding a value feels inflexible.

1. The operator image was referenced by the bundle with a tag, rather than by digest. I fixed this in [L64-65](https://github.com/WASdev/websphere-liberty-operator/pull/52/files#diff-39d64910fb95c6a30f0ac1d69eb939b3082111efed9bd8108ae1ef1fb92d20deR64-R65) of `bundle-release.sh` by retrieving the digest of the provided image (in staging) with `skopeo` and appending it to the name of the "production image" (where the image would be at icr.io).

See a successful build [here.](https://cloud.ibm.com/devops/pipelines/tekton/c3b2797d-c8ad-4dab-9660-2ec8c0643a76/runs/33755e0a-32d3-4f7d-8221-5022751a7c90?env_id=ibm:yp:us-south)