### PR TITLE
Fix container command selection logic in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,8 @@ endif
 
 # Use docker if available. Otherwise default to podman. 
 # Override choice by setting CONTAINER_COMMAND
-ifneq (, $(shell which docker))
-CONTAINER_COMMAND ?= "podman"
+ifeq (, $(shell which docker))
+CONTAINER_COMMAND ?= podman
 # Setup parameters for TLS verify, default if unspecified is true
 ifeq (false, $(TLS_VERIFY))
 PODMAN_SKIP_TLS_VERIFY="--tls-verify=false"
@@ -77,7 +77,7 @@ TLS_VERIFY ?= true
 PODMAN_SKIP_TLS_VERIFY="--tls-verify=true"
 endif
 else
-CONTAINER_COMMAND ?= "docker"
+CONTAINER_COMMAND ?= docker
 endif
 
 all: build

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,8 @@ endif
 
 # Use docker if available. Otherwise default to podman. 
 # Override choice by setting CONTAINER_COMMAND
-ifeq (, $(shell which docker))
+CHECK_DOCKER_RC=$(shell docker -v > /dev/null 2>&1; echo $$?)
+ifneq (0, $(CHECK_DOCKER_RC))
 CONTAINER_COMMAND ?= podman
 # Setup parameters for TLS verify, default if unspecified is true
 ifeq (false, $(TLS_VERIFY))


### PR DESCRIPTION
related to #10 

In the pipeline, I noticed that it had selected `podman` to push images, which was failing since `podman` is not installed:

```
Successfully built 1c1b2b81dbb9
Successfully tagged cp.stg.icr.io/cp/websphere-liberty-operator-catalog:1.0.0-20220330-1800
make docker-push IMG="cp.stg.icr.io/cp/websphere-liberty-operator-catalog:1.0.0-20220330-1800"
make[1]: Entering directory '/workspace/app/one-pipeline-config-repo'
"podman" push "--tls-verify=true" cp.stg.icr.io/cp/websphere-liberty-operator-catalog:1.0.0-20220330-1800
/bin/sh: 1: podman: not found
Makefile:136: recipe for target 'docker-push' failed
make[1]: *** [docker-push] Error 127
```

Upon inspecting the Makefile I noticed this behavior was caused by [this code](https://github.com/WASdev/websphere-liberty-operator/blob/a649cbb140097b62fd4c99bccd67d569ab9f6f2f/Makefile#L69-L70):

```make
ifneq (, $(shell which docker))
CONTAINER_COMMAND ?= "podman"
```

This code actually does the opposite of what is intended. If `docker` is installed, it will evaluate to a valid path, which will select `podman`. This is equivalent to something like:

```python
if "/usr/local/bin/docker" != "":         # since docker is installed this evaluates to true
   CONTAINER_COMMAND = "podman"
```

To fix this and add more reliability between various machines, I'm instead now checking if `docker` is installed by running `docker -v` and getting the return/exit code. 0 indicates that `docker` is installed, and anything else (like 127, which means "not found") indicates `podman` should be used instead.