### PR TITLE
Set ImplementationSpecific as default for Ingress path type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/WASdev/websphere-liberty-operator
 go 1.16
 
 require (
-	github.com/application-stacks/runtime-component-operator v0.8.1-0.20220404160633-8e29709d8e1d
+	github.com/application-stacks/runtime-component-operator v0.8.1-0.20220405182540-00ecc1f1f51d
 	github.com/coreos/prometheus-operator v0.41.1
 	github.com/go-logr/logr v0.3.0
 	github.com/openshift/api v0.0.0-20201019163320-c6a5ec25f267

--- a/go.sum
+++ b/go.sum
@@ -205,12 +205,8 @@ github.com/apex/log v1.3.0/go.mod h1:jd8Vpsr46WAe3EZSQ/IUMs2qQD/GOycT5rPWCO1yGcs
 github.com/apex/logs v0.0.4/go.mod h1:XzxuLZ5myVHDy9SAmYpamKKRNApGj54PfYLcFrXqDwo=
 github.com/aphistic/golf v0.0.0-20180712155816-02c07f170c5a/go.mod h1:3NqKYiepwy8kCu4PNA+aP7WUV72eXWJeP9/r3/K9aLE=
 github.com/aphistic/sweet v0.2.0/go.mod h1:fWDlIh/isSE9n6EPsRmC0det+whmX6dJid3stzu0Xys=
-github.com/application-stacks/runtime-component-operator v0.8.1-0.20220124145716-73885bed49ff h1:jqBAquxD6LIP2VtcBeroTGiCZlYdx3Dvt4P0f/9o5xI=
-github.com/application-stacks/runtime-component-operator v0.8.1-0.20220124145716-73885bed49ff/go.mod h1:h365eRTO2WuA+IYMxW/DrOZCqePnX7NyxN5MzqsV20k=
-github.com/application-stacks/runtime-component-operator v0.8.1-0.20220331203419-044b87e47baa h1:3fCFpOEXQeqopbNKWQJJ2uv9pBmqTNwo/RCmVxWZ3J8=
-github.com/application-stacks/runtime-component-operator v0.8.1-0.20220331203419-044b87e47baa/go.mod h1:h365eRTO2WuA+IYMxW/DrOZCqePnX7NyxN5MzqsV20k=
-github.com/application-stacks/runtime-component-operator v0.8.1-0.20220404160633-8e29709d8e1d h1:I9AFU4FxnQpEX3V0iWArYr4rNj29myGt6MMozE4IeWg=
-github.com/application-stacks/runtime-component-operator v0.8.1-0.20220404160633-8e29709d8e1d/go.mod h1:h365eRTO2WuA+IYMxW/DrOZCqePnX7NyxN5MzqsV20k=
+github.com/application-stacks/runtime-component-operator v0.8.1-0.20220405182540-00ecc1f1f51d h1:wqeot/blEksWnzophJTZ9ANxiizdK7Z1kGIhjOinu2s=
+github.com/application-stacks/runtime-component-operator v0.8.1-0.20220405182540-00ecc1f1f51d/go.mod h1:h365eRTO2WuA+IYMxW/DrOZCqePnX7NyxN5MzqsV20k=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=


### PR DESCRIPTION
Ingress resource requires pathType field to be specified. If not set, error will occur. Set ImplementationSpecific as the default value.