### PR TITLE
Fix catalog build issue and enable branch protection

### DIFF
--- a/.one-pipeline.yaml
+++ b/.one-pipeline.yaml
@@ -16,15 +16,14 @@ setup:
     BRANCH=$(get_env branch)
 
     if [[ "$ENABLE_BRANCH_PROTECTION" == "true" && "$BRANCH" != "main" ]]; then
-      #GHE_TOKEN=$(get_env git-public-token)
-      #OWNER=$(jq -r '.services[] | select(.toolchain_binding.name=="app-repo") | .parameters.owner_id' /toolchain/toolchain.json)
+      GHE_TOKEN=$(get_env git-public-token)
       REPO=$(get_env app-repo)
+      REPO="$(echo ${REPO%.git} | sed 's/https:\/\/github.com\///')"
 
-      #echo "Owner: $OWNER"
       echo "REPO: $REPO"
-      #echo "BRANCH: $BRANCH"
+      echo "BRANCH: $BRANCH"
 
-      #curl -u :$GH_TOKEN https://api.github.com/repos/$OWNER/$REPO/branches/$BRANCH/protection -H "Accept: application/vnd.github.v3+json" -X PUT -d '{"required_pull_request_reviews":{"dismiss_stale_reviews":true,"required_approving_review_count":1},"enforce_admins":null,"restrictions":null,"required_status_checks":null}'
+      curl -u :$GH_TOKEN https://api.github.com/repos/$REPO/branches/$BRANCH/protection -H "Accept: application/vnd.github.v3+json" -X PUT -d '{"required_pull_request_reviews":{"dismiss_stale_reviews":true,"required_approving_review_count":1},"enforce_admins":null,"restrictions":null,"required_status_checks":null}'
     fi
   
 test:

--- a/.one-pipeline.yaml
+++ b/.one-pipeline.yaml
@@ -16,15 +16,15 @@ setup:
     BRANCH=$(get_env branch)
 
     if [[ "$ENABLE_BRANCH_PROTECTION" == "true" && "$BRANCH" != "main" ]]; then
-      GHE_TOKEN=$(get_env git-public-token)
-      OWNER=$(jq -r '.services[] | select(.toolchain_binding.name=="app-repo") | .parameters.owner_id' /toolchain/toolchain.json)
-      REPO=$(jq -r '.services[] | select(.toolchain_binding.name=="app-repo") | .parameters.repo_name' /toolchain/toolchain.json)
+      #GHE_TOKEN=$(get_env git-public-token)
+      #OWNER=$(jq -r '.services[] | select(.toolchain_binding.name=="app-repo") | .parameters.owner_id' /toolchain/toolchain.json)
+      REPO=$(get_env app-repo)
 
-      echo "Owner: $OWNER"
+      #echo "Owner: $OWNER"
       echo "REPO: $REPO"
-      echo "BRANCH: $BRANCH"
+      #echo "BRANCH: $BRANCH"
 
-      curl -u :$GH_TOKEN https://api.github.com/repos/$OWNER/$REPO/branches/$BRANCH/protection -H "Accept: application/vnd.github.v3+json" -X PUT -d '{"required_pull_request_reviews":{"dismiss_stale_reviews":true,"required_approving_review_count":1},"enforce_admins":null,"restrictions":null,"required_status_checks":null}'
+      #curl -u :$GH_TOKEN https://api.github.com/repos/$OWNER/$REPO/branches/$BRANCH/protection -H "Accept: application/vnd.github.v3+json" -X PUT -d '{"required_pull_request_reviews":{"dismiss_stale_reviews":true,"required_approving_review_count":1},"enforce_admins":null,"restrictions":null,"required_status_checks":null}'
     fi
   
 test:

--- a/.one-pipeline.yaml
+++ b/.one-pipeline.yaml
@@ -15,7 +15,8 @@ setup:
     ENABLE_BRANCH_PROTECTION=$(get_env enable-branch-protection)
     BRANCH=$(get_env branch)
 
-    if [[ "$ENABLE_BRANCH_PROTECTION" == "true" && "$BRANCH" != "main" ]]; then
+    # Only enable branch protection on branches that are not "main" or a patch branch (e.g. 1.1.x)
+    if [[ "$ENABLE_BRANCH_PROTECTION" == "true" && "$BRANCH" != "main" && ! "$BRANCH" =~ [0-9](.[0-9])?.x ]]; then
       GHE_TOKEN=$(get_env git-public-token)
       REPO=$(get_env app-repo)
       REPO="$(echo ${REPO%.git} | sed 's/https:\/\/github.com\///')"

--- a/.one-pipeline.yaml
+++ b/.one-pipeline.yaml
@@ -10,15 +10,22 @@ setup:
     apt-get update
     apt-get -y install build-essential
     rm -rf /usr/local/go && tar -C /usr/local -xf go1.16.linux-amd64.tar.gz
-    # Added `go mod vendor` here because without it, the following error was generated:
-    # go test -v -mod=vendor -tags=unit github.com/WASdev/websphere-liberty-operator/...
-    # go: inconsistent vendoring in /workspace/app/one-pipeline-config-repo:
-    #   ... (list of pkgs) ...
-    #   To ignore the vendor directory, use -mod=readonly or -mod=mod.
-    #   To sync the vendor directory, run:
-    #     go mod vendor
-    # TODO: determine if this is necessary/best solution.
     go mod vendor
+
+    ENABLE_BRANCH_PROTECTION=$(get_env enable-branch-protection)
+    BRANCH=$(get_env branch)
+
+    if [[ "$ENABLE_BRANCH_PROTECTION" == "true" && "$BRANCH" != "main" ]]; then
+      GHE_TOKEN=$(get_env git-public-token)
+      OWNER=$(jq -r '.services[] | select(.toolchain_binding.name=="app-repo") | .parameters.owner_id' /toolchain/toolchain.json)
+      REPO=$(jq -r '.services[] | select(.toolchain_binding.name=="app-repo") | .parameters.repo_name' /toolchain/toolchain.json)
+
+      echo "Owner: $OWNER"
+      echo "REPO: $REPO"
+      echo "BRANCH: $BRANCH"
+
+      curl -u :$GH_TOKEN https://api.github.com/repos/$OWNER/$REPO/branches/$BRANCH/protection -H "Accept: application/vnd.github.v3+json" -X PUT -d '{"required_pull_request_reviews":{"dismiss_stale_reviews":true,"required_approving_review_count":1},"enforce_admins":null,"restrictions":null,"required_status_checks":null}'
+    fi
   
 test:
   dind: true

--- a/scripts/catalog-build.sh
+++ b/scripts/catalog-build.sh
@@ -87,10 +87,9 @@ function create_empty_db() {
 function add_to_db(){
     local stg_img=$1
     local prod_img=$2
-    local digest="$(skopeo inspect docker://$stg_img | grep Digest | grep -o 'sha[^\"]*')"
+    local digest="$(docker pull $stg_img | grep Digest | grep -o 'sha[^\"]*')"
     local img_digest="${prod_img}@${digest}"
     echo "------------ adding bundle image ${img_digest} to ${TMP_DIR}/bundles.db ------------"
-    docker pull $stg_img
     "${OPM_TOOL}" registry add -b "${img_digest}" -d "${TMP_DIR}/bundles.db" -c "${CONTAINER_TOOL}" --permissive
 }
 

--- a/scripts/catalog-build.sh
+++ b/scripts/catalog-build.sh
@@ -87,9 +87,11 @@ function create_empty_db() {
 function add_to_db(){
     local stg_img=$1
     local prod_img=$2
+    local img_tag="$(echo $stg_img | cut -d ':' -f 2)"
     local digest="$(skopeo inspect docker://$stg_img | grep Digest | grep -o 'sha[^\"]*')"
     local img_digest="${prod_img}@${digest}"
     echo "------------ adding bundle image ${img_digest} to ${TMP_DIR}/bundles.db ------------"
+    docker tag $stg_img $prod_img:$img_tag
     "${OPM_TOOL}" registry add -b "${img_digest}" -d "${TMP_DIR}/bundles.db" -c "${CONTAINER_TOOL}" --permissive
 }
 

--- a/scripts/catalog-build.sh
+++ b/scripts/catalog-build.sh
@@ -87,11 +87,10 @@ function create_empty_db() {
 function add_to_db(){
     local stg_img=$1
     local prod_img=$2
-    local img_tag="$(echo $stg_img | cut -d ':' -f 2)"
     local digest="$(skopeo inspect docker://$stg_img | grep Digest | grep -o 'sha[^\"]*')"
     local img_digest="${prod_img}@${digest}"
     echo "------------ adding bundle image ${img_digest} to ${TMP_DIR}/bundles.db ------------"
-    docker tag $stg_img $prod_img:$img_tag
+    docker pull $stg_img
     "${OPM_TOOL}" registry add -b "${img_digest}" -d "${TMP_DIR}/bundles.db" -c "${CONTAINER_TOOL}" --permissive
 }
 


### PR DESCRIPTION
We noticed an issue (https://github.ibm.com/IBMCloudPak4Apps/wshe-OnePipeline/issues/81) where the catalog did not include the image. This was because `opm registry add` was unable to add the local image to the registry since it did not have a digest "attached" to it. To fix this all that was needed was a `docker pull`, which I snuck into the command to get the digest.

I also added code to enable branch protection, which is currently having permissions issues, but it should work once our ID has permission to update branch protection rules. If more code is needed I'll open another PR.