### PR TITLE
Increase timeout of run bundle to 5 mins

### DIFF
--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -107,7 +107,7 @@ main() {
     push_images
 
     echo "****** Installing bundle..."
-    operator-sdk run bundle --install-mode OwnNamespace --pull-secret-name regcred "${BUNDLE_IMAGE}" || {
+    operator-sdk run bundle --install-mode OwnNamespace --pull-secret-name regcred "${BUNDLE_IMAGE}" --timeout 5m || {
         echo "****** Installing bundle failed..."
         exit 1
     }

--- a/scripts/pipeline/fyre-e2e.sh
+++ b/scripts/pipeline/fyre-e2e.sh
@@ -129,7 +129,7 @@ main() {
     oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson=/tmp/pull-secret-merged.yaml
 
     echo "****** Installing Bundle image: ${BUNDLE_IMAGE}"
-    operator-sdk run bundle --install-mode OwnNamespace --pull-secret-name regcred "${BUNDLE_IMAGE}" || {
+    operator-sdk run bundle --install-mode OwnNamespace --pull-secret-name regcred "${BUNDLE_IMAGE}" --timeout 5m || {
         echo "****** Installing bundle failed..."
         exit 1
     }


### PR DESCRIPTION
The e2e step consistently fails in builds due to running the bundle does not complete within the default 2 minutes. Increase timeout to 5 minutes. 

Sample build log:
```
****** Installing Bundle image: [cp.stg.icr.io/cp/websphere-liberty-operator-bundle:1.0.0-20220410-1300](http://cp.stg.icr.io/cp/websphere-liberty-operator-bundle:1.0.0-20220410-1300)
time="2022-04-10T18:24:03Z" level=info msg="Successfully created registry pod: icr-io-cp-websphere-liberty-operator-bundle-1-0-0-20220410-1300"
time="2022-04-10T18:24:03Z" level=info msg="Created CatalogSource: ibm-websphere-liberty-catalog"
time="2022-04-10T18:24:03Z" level=info msg="OperatorGroup \"operator-sdk-og\" created"
time="2022-04-10T18:24:04Z" level=info msg="Created Subscription: ibm-websphere-liberty-v1-0-0-sub"
time="2022-04-10T18:24:07Z" level=info msg="Approved InstallPlan install-bzpgv for the Subscription: ibm-websphere-liberty-v1-0-0-sub"
time="2022-04-10T18:24:07Z" level=info msg="Waiting for ClusterServiceVersion \"wlo-test-166/ibm-websphere-liberty.v1.0.0\" to reach 'Succeeded' phase"
time="2022-04-10T18:24:07Z" level=info msg="  Waiting for ClusterServiceVersion \"wlo-test-166/ibm-websphere-liberty.v1.0.0\" to appear"
time="2022-04-10T18:24:19Z" level=info msg="  Found ClusterServiceVersion \"wlo-test-166/ibm-websphere-liberty.v1.0.0\" phase: Pending"
time="2022-04-10T18:25:56Z" level=fatal msg="Failed to run bundle: error waiting for CSV to install: deployment wlo-controller-manager has error: context deadline exceeded\n\n"
****** Installing bundle failed...
Makefile:288: recipe for target 'test-pipeline-e2e' failed
make: *** [test-pipeline-e2e] Error 1
```
Signed-off-by: Leo Christy Jesuraj <leojc@ca.ibm.com>