### PR TITLE
Enable aqua scans for WLO

### DIFF
--- a/.one-pipeline.yaml
+++ b/.one-pipeline.yaml
@@ -236,6 +236,18 @@ scan-artifact:
       done
     fi
 
+    echo "aqua scan"
+    # install docker
+    curl -fsSL https://get.docker.com -o get-docker.sh
+    sudo sh get-docker.sh
+    # get aqua scan executables
+    git clone https://$(get_env git-token)@github.ibm.com/CICD-CPP/cpp-pipelines.git
+    chmod -R +x cpp-pipelines
+    # setup and execute aqua scan
+    cd cpp-pipelines
+    export CUSTOM_SCRIPTS_PATH=/workspace/app/one-pipeline-config-repo/cpp-pipelines
+    ./commons/aqua/aqua-local-scan
+
 release:
   abort_on_failure: false
   image: wcp-compliance-automation-team-docker-local.artifactory.swg-devops.com/ibm-compliance-automation:1.9.1@sha256:3f3e344a1efb160d83c48cf2ee878a39cbad058c8640c423472e0546316232fd


### PR DESCRIPTION
This code enables the aqua scan as part of the scan-artifact stage. You can see a successful run here: https://cloud.ibm.com/devops/pipelines/tekton/c3b2797d-c8ad-4dab-9660-2ec8c0643a76/runs/a4e56f76-5146-43b6-9b80-9c7e421ef6e0/build-scan-artifact/run-stage?env_id=ibm:yp:us-south