### PR TITLE
Delete the trace CR at the end of test

### DIFF
--- a/bundle/tests/scorecard/kuttl/trace/04-delete-app.yaml
+++ b/bundle/tests/scorecard/kuttl/trace/04-delete-app.yaml
@@ -5,3 +5,6 @@ delete:
   - apiVersion: liberty.websphere.ibm.com/v1
     kind: WebSphereLibertyApplication
     name: trace-ws
+  - apiVersion: liberty.websphere.ibm.com/v1
+    kind: WebSphereLibertyTrace
+    name: example-trace


### PR DESCRIPTION
Delete the trace CR at the end of the test. It has a finalizer that prevents the namespace/project from being deleted.