### PR TITLE
Remove ReadWriteOnce from serviceability PVC

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -250,7 +250,6 @@ func CreateServiceabilityPVC(instance *wlv1.WebSphereLibertyApplication) *corev1
 			},
 			AccessModes: []corev1.PersistentVolumeAccessMode{
 				corev1.ReadWriteMany,
-				corev1.ReadWriteOnce,
 			},
 		},
 	}


### PR DESCRIPTION
Serviceability's default PVC requests both ReadWriteMany and ReadWriteOnce. Volume is picked only if it supports ALL access modes. but ReadWriteOnce is not required, so remove it.