### PR TITLE
Update kuttl rbac

### DIFF
--- a/config/rbac/kuttl-rbac.yaml
+++ b/config/rbac/kuttl-rbac.yaml
@@ -56,6 +56,7 @@ rules:
   verbs:
   - get
   - create
+  - patch
 - apiGroups:
   - autoscaling
   resources:

--- a/config/rbac/minikube-kuttl-rbac.yaml
+++ b/config/rbac/minikube-kuttl-rbac.yaml
@@ -49,6 +49,7 @@ rules:
   verbs:
   - get
   - create
+  - patch
 - apiGroups:
   - autoscaling
   resources:

--- a/scripts/pipeline/fyre-e2e.sh
+++ b/scripts/pipeline/fyre-e2e.sh
@@ -195,6 +195,9 @@ kind: OperatorGroup
 metadata:
   name: websphere-operator-group
   namespace: $TEST_NAMESPACE
+spec:
+  targetNamespaces:
+    - $TEST_NAMESPACE
 EOF
 
     echo "****** Applying the subscription..."


### PR DESCRIPTION
- Update kuttl rbac to include `patch` role for `deployment`
- Update the e2e test to run in SingleNamespace mode. Otherwise, a build failure prevents subsequent runs since the operator, installed in AllNamespaces, is not uninstalled when failure occurs