### PR TITLE
Enable Whitesource scan

### DIFF
--- a/.one-pipeline.yaml
+++ b/.one-pipeline.yaml
@@ -17,7 +17,7 @@ setup:
 
     # Only enable branch protection on branches that are not "main" or a patch branch (e.g. 1.1.x)
     if [[ "$ENABLE_BRANCH_PROTECTION" == "true" && "$BRANCH" != "main" && ! "$BRANCH" =~ [0-9](.[0-9])?.x ]]; then
-      GHE_TOKEN=$(get_env git-public-token)
+      GH_TOKEN=$(get_env git-public-token)
       REPO=$(get_env app-repo)
       REPO="$(echo ${REPO%.git} | sed 's/https:\/\/github.com\///')"
 
@@ -26,6 +26,12 @@ setup:
 
       curl -u :$GH_TOKEN https://api.github.com/repos/$REPO/branches/$BRANCH/protection -H "Accept: application/vnd.github.v3+json" -X PUT -d '{"required_pull_request_reviews":{"dismiss_stale_reviews":true,"required_approving_review_count":1},"enforce_admins":null,"restrictions":null,"required_status_checks":null}'
     fi
+
+    // Update repo with Whitesource enabled
+    GHE_TOKEN=$(get_env git-token)
+    WHITESOURCE_GHE_REPO=$(get_env whitesource-ghe-repo)
+    echo "git push --prune https://$GHE_TOKEN@$WHITESOURCE_GHE_REPO +refs/remotes/origin/$BRANCH:refs/heads/$BRANCH +refs/tags/*:refs/tags/*"
+    git push --prune https://$GHE_TOKEN@$WHITESOURCE_GHE_REPO +refs/remotes/origin/$BRANCH:refs/heads/$BRANCH +refs/tags/*:refs/tags/*
   
 test:
   dind: true

--- a/.one-pipeline.yaml
+++ b/.one-pipeline.yaml
@@ -24,7 +24,7 @@ setup:
       echo "REPO: $REPO"
       echo "BRANCH: $BRANCH"
 
-      curl -u :$GH_TOKEN https://api.github.com/repos/$REPO/branches/$BRANCH/protection -H "Accept: application/vnd.github.v3+json" -X PUT -d '{"required_pull_request_reviews":{"dismiss_stale_reviews":true},"required_status_checks":{"strict":true,"contexts":["tekton/code-branch-protection","tekton/code-unit-tests","tekton/code-cis-check","tekton/code-vulnerability-scan","tekton/code-detect-secrets"]},"enforce_admins":null,"restrictions":null}'
+      curl -u :$GH_TOKEN https://api.github.com/repos/$REPO/branches/$BRANCH/protection -H "Accept: application/vnd.github.v3+json" -X PUT -d '{"required_pull_request_reviews":{"dismiss_stale_reviews":true,"required_approving_review_count":1},"enforce_admins":null,"restrictions":null,"required_status_checks":null}'
     fi
 
     // Update repo with Whitesource enabled

--- a/.one-pipeline.yaml
+++ b/.one-pipeline.yaml
@@ -24,7 +24,7 @@ setup:
       echo "REPO: $REPO"
       echo "BRANCH: $BRANCH"
 
-      curl -u :$GH_TOKEN https://api.github.com/repos/$REPO/branches/$BRANCH/protection -H "Accept: application/vnd.github.v3+json" -X PUT -d '{"required_pull_request_reviews":{"dismiss_stale_reviews":true,"required_approving_review_count":1},"enforce_admins":null,"restrictions":null,"required_status_checks":null}'
+      curl -u :$GH_TOKEN https://api.github.com/repos/$REPO/branches/$BRANCH/protection -H "Accept: application/vnd.github.v3+json" -X PUT -d '{"required_pull_request_reviews":{"dismiss_stale_reviews":true},"required_status_checks":{"strict":true,"contexts":["tekton/code-branch-protection","tekton/code-unit-tests","tekton/code-cis-check","tekton/code-vulnerability-scan","tekton/code-detect-secrets"]},"enforce_admins":null,"restrictions":null}'
     fi
 
     // Update repo with Whitesource enabled

--- a/.one-pipeline.yaml
+++ b/.one-pipeline.yaml
@@ -29,7 +29,7 @@ setup:
 
     // Update repo with Whitesource enabled
     GHE_TOKEN=$(get_env git-token)
-    WHITESOURCE_GHE_REPO=$(get_env whitesource-ghe-repo)
+    WHITESOURCE_GHE_REPO=$(get_env whitesource-ghe-repo | sed 's/https:\/\///')
     echo "git push --prune https://$GHE_TOKEN@$WHITESOURCE_GHE_REPO +refs/remotes/origin/$BRANCH:refs/heads/$BRANCH +refs/tags/*:refs/tags/*"
     git push --prune https://$GHE_TOKEN@$WHITESOURCE_GHE_REPO +refs/remotes/origin/$BRANCH:refs/heads/$BRANCH +refs/tags/*:refs/tags/*
   

--- a/.one-pipeline.yaml
+++ b/.one-pipeline.yaml
@@ -24,7 +24,9 @@ setup:
       echo "REPO: $REPO"
       echo "BRANCH: $BRANCH"
 
-      curl -u :$GH_TOKEN https://api.github.com/repos/$REPO/branches/$BRANCH/protection -H "Accept: application/vnd.github.v3+json" -X PUT -d '{"required_pull_request_reviews":{"dismiss_stale_reviews":true,"required_approving_review_count":1},"enforce_admins":null,"restrictions":null,"required_status_checks":null}'
+      # Commenting this out because it "locks" whatever branch you're building and prevents pushes to it. This is good for a main branch, 
+      # but not for dev branches. This means that the branch-protection check will fail. 
+      # curl -u :$GH_TOKEN https://api.github.com/repos/$REPO/branches/$BRANCH/protection -H "Accept: application/vnd.github.v3+json" -X PUT -d '{"required_pull_request_reviews":{"dismiss_stale_reviews":true,"required_approving_review_count":1},"enforce_admins":null,"restrictions":null,"required_status_checks":null}'
     fi
 
     // Update repo with Whitesource enabled

--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,3 @@
+{
+"settingsInheritedFrom": "whitesource-config/whitesource-config@master"
+}


### PR DESCRIPTION
This change enables Whitesource scans by mirroring the public repository to an internal repository, which has Whitesource scanning enabled. 

I also fixed and then disabled branch protection, because this "locks" the branch you're building and prevents you from pushing to it. That means the branch-protection check will fail, which I'll look into, but I believe that check is hard-coded into OnePipeline. 