### PR TITLE
Determine whether to push branch or tag to Whitesource scan repo

### DIFF
--- a/.one-pipeline.yaml
+++ b/.one-pipeline.yaml
@@ -1,4 +1,4 @@
-version: '1'
+version: "1"
 
 setup:
   image: icr.io/continuous-delivery/pipeline/pipeline-base-image:2.12@sha256:ff4053b0bca784d6d105fee1d008cfb20db206011453071e86b69ca3fde706a4
@@ -32,23 +32,35 @@ setup:
     // Update repo with Whitesource enabled
     GHE_TOKEN=$(get_env git-token)
     WHITESOURCE_GHE_REPO=$(get_env whitesource-ghe-repo | sed 's/https:\/\///')
-    echo "git push --prune https://$GHE_TOKEN@$WHITESOURCE_GHE_REPO +refs/remotes/origin/$BRANCH:refs/heads/$BRANCH +refs/tags/*:refs/tags/*"
-    git push --prune https://$GHE_TOKEN@$WHITESOURCE_GHE_REPO +refs/remotes/origin/$BRANCH:refs/heads/$BRANCH +refs/tags/*:refs/tags/*
-  
+    REF_SRC="refs/remotes/origin/$BRANCH"
+
+    if [[ -f ".git/refs/remotes/origin/$BRANCH" ]];
+      echo "Pushing branch $BRANCH to $WHITESOURCE_GHE_REPO"
+    elif [[ -f ".git/refs/tags/$BRANCH" ]];
+      echo "The given 'branch' ($BRANCH) is a tag. Creating a branch from it for scanning."
+      git checkout -b "$BRANCH" "$BRANCH"
+      REF_SRC="$BRANCH"
+    else
+      echo "Warning: Could not find a matching branch or tag named '$BRANCH'. Trying anyway!"
+    fi
+
+    echo "git push --prune https://$GHE_TOKEN@$WHITESOURCE_GHE_REPO +"$REF_SRC":refs/heads/$BRANCH +refs/tags/*:refs/tags/*"
+    git push --prune https://$GHE_TOKEN@$WHITESOURCE_GHE_REPO +"$REF_SRC":refs/heads/$BRANCH +refs/tags/*:refs/tags/*
+
 test:
   dind: true
   abort_on_failure: true
   image: icr.io/continuous-delivery/pipeline/pipeline-base-image:2.12@sha256:ff4053b0bca784d6d105fee1d008cfb20db206011453071e86b69ca3fde706a4
   script: |
     #!/usr/bin/env bash
-    
+
     ## Setup required tooling
     wget --header "Accept: application/octet-stream"  "https://golang.org/dl/go1.16.linux-amd64.tar.gz" 
     rm -rf /usr/local/go && tar -C /usr/local -xf go1.16.linux-amd64.tar.gz
     export PATH=$PATH:/usr/local/go/bin
     apt-get update
     apt-get -y install build-essential
-    
+
     make unit-test
 
 static-scan:
@@ -90,14 +102,14 @@ containerize:
       env
       set -x
     fi
-    
+
     # Download and configure golang
     wget --header "Accept: application/octet-stream"  "https://golang.org/dl/go1.16.linux-amd64.tar.gz"
     rm -rf /usr/local/go && tar -C /usr/local -xf go1.16.linux-amd64.tar.gz
     export PATH=$PATH:/usr/local/go/bin
     apt-get update
     apt-get -qq -y install build-essential software-properties-common uidmap
-    
+
     # Download and install skopeo
     if ! command -v skopeo &> /dev/null; then
       if [ ! -f "/apt/sources.list.d/devel:kubic:libcontainers:stable.list" ]; then
@@ -109,7 +121,7 @@ containerize:
     else
       skopeo --version
     fi
-    
+
     #  Build images
     export PIPELINE_USERNAME=$(get_env ibmcloud-api-user)
     export PIPELINE_PASSWORD=$(get_env ibmcloud-api-key-staging)
@@ -124,14 +136,14 @@ containerize:
     export REDHAT_BASE_IMAGE=$(get_env redhat-base-image)
     export REDHAT_REGISTRY=$(get_env redhat-registry)
     export OPM_VERSION=$(get_env opm-version)
-    
+
     # Build amd64 image
     make build-pipeline-releases
-    
+
     # Build ppc64le and s390x images
     # Disabled for Liberty Operator builds for now
     #./scripts/pipeline/launch-travis.sh -t $(get_env travis-token) -r "https://github.com/WASDev/websphere-liberty-operator" -b $(get_env branch) -l
-    
+
     # Build manifest
     make build-pipeline-manifest
 
@@ -278,43 +290,43 @@ scan-artifact:
     ./commons/aqua/aqua-local-scan
 
 release:
-    abort_on_failure: false
-    image: icr.io/continuous-delivery/pipeline/pipeline-base-image:2.12@sha256:ff4053b0bca784d6d105fee1d008cfb20db206011453071e86b69ca3fde706a4
-    script: |
-      #!/usr/bin/env bash
+  abort_on_failure: false
+  image: icr.io/continuous-delivery/pipeline/pipeline-base-image:2.12@sha256:ff4053b0bca784d6d105fee1d008cfb20db206011453071e86b69ca3fde706a4
+  script: |
+    #!/usr/bin/env bash
 
-      SKIP_ALL_CHECKS=$(get_env SKIP_ALL_CHECKS "false")
-      ./scripts/pipeline/evaluator.sh      
-      if [[ $? == 0 || $SKIP_ALL_CHECKS == "true" ]]; then
-        if [[  $SKIP_ALL_CHECKS == "true" ]]; then
-          echo "Skipping image scan checks"
-        fi
-        APP_REPO=$(pwd)
-        echo "Application Repository: $APP_REPO"
-        # export GIT_AUTH_USER=${GIT_AUTH_USER}
-        INVENTORY_REPO=$(get_env inventory-repo)       
-        echo "Cloning inventory repository: $INVENTORY_REPO"
-        cd "$WORKSPACE"
-        APP_TOKEN_PATH="$WORKSPACE/secrets/app-token"
-        . "${ONE_PIPELINE_PATH}"/git/clone_repo \
-          "$INVENTORY_REPO" \
-          "master"  \
-          "" \
-          "$APP_TOKEN_PATH" 
-        REPO=${INVENTORY_REPO##*/} 
-        NAME=${REPO%.*}
-        echo "Inventory name: $NAME"
-        cd $WORKSPACE/$NAME
-        if [ "$(ls )" ]; then
-          echo "Clearing inventory repository: $INVENTORY_REPO"
-          git config --global user.email "tekton@example.com"
-          git config --global user.name "Tekton"
-          git rm *
-          git commit -m "Delete contents of inventory repository - $PIPELINE_RUN_ID"
-          git push origin master
-        fi
-        cd $APP_REPO   
-        ./scripts/pipeline/release.sh
-      else
-        echo "Errors found.  images will not be released"
+    SKIP_ALL_CHECKS=$(get_env SKIP_ALL_CHECKS "false")
+    ./scripts/pipeline/evaluator.sh      
+    if [[ $? == 0 || $SKIP_ALL_CHECKS == "true" ]]; then
+      if [[  $SKIP_ALL_CHECKS == "true" ]]; then
+        echo "Skipping image scan checks"
       fi
+      APP_REPO=$(pwd)
+      echo "Application Repository: $APP_REPO"
+      # export GIT_AUTH_USER=${GIT_AUTH_USER}
+      INVENTORY_REPO=$(get_env inventory-repo)       
+      echo "Cloning inventory repository: $INVENTORY_REPO"
+      cd "$WORKSPACE"
+      APP_TOKEN_PATH="$WORKSPACE/secrets/app-token"
+      . "${ONE_PIPELINE_PATH}"/git/clone_repo \
+        "$INVENTORY_REPO" \
+        "master"  \
+        "" \
+        "$APP_TOKEN_PATH" 
+      REPO=${INVENTORY_REPO##*/} 
+      NAME=${REPO%.*}
+      echo "Inventory name: $NAME"
+      cd $WORKSPACE/$NAME
+      if [ "$(ls )" ]; then
+        echo "Clearing inventory repository: $INVENTORY_REPO"
+        git config --global user.email "tekton@example.com"
+        git config --global user.name "Tekton"
+        git rm *
+        git commit -m "Delete contents of inventory repository - $PIPELINE_RUN_ID"
+        git push origin master
+      fi
+      cd $APP_REPO   
+      ./scripts/pipeline/release.sh
+    else
+      echo "Errors found.  images will not be released"
+    fi

--- a/.one-pipeline.yaml
+++ b/.one-pipeline.yaml
@@ -33,10 +33,10 @@ setup:
     GHE_TOKEN=$(get_env git-token)
     WHITESOURCE_GHE_REPO=$(get_env whitesource-ghe-repo | sed 's/https:\/\///')
 
-    if [[ -f ".git/refs/remotes/origin/$BRANCH" ]]; then
+    if [[ -n "$(git branch --list -r origin/$BRANCH)" ]]; then
       echo "Pushing branch $BRANCH to $WHITESOURCE_GHE_REPO"
       REFS="+refs/remotes/origin/$BRANCH:refs/heads/$BRANCH +refs/tags/*:refs/tags/*"
-    elif [[ -f ".git/refs/tags/$BRANCH" ]]; then
+    elif [[ -n "$(git tag --list $BRANCH)" ]]; then
       echo "The given 'branch' ($BRANCH) is a tag. Pushing it to $WHITESOURCE_GHE_REPO."
       REFS="+refs/tags/$BRANCH:refs/tags/$BRANCH"
     else

--- a/.one-pipeline.yaml
+++ b/.one-pipeline.yaml
@@ -44,7 +44,7 @@ setup:
     fi
 
     echo "git push --prune https://$GHE_TOKEN@$WHITESOURCE_GHE_REPO $BRANCH_REFSPEC +refs/tags/*:refs/tags/*"
-    git push --prune https://$GHE_TOKEN@$WHITESOURCE_GHE_REPO "$BRANCH_REFSPEC" +refs/tags/*:refs/tags/*
+    git push --prune https://$GHE_TOKEN@$WHITESOURCE_GHE_REPO $BRANCH_REFSPEC +refs/tags/*:refs/tags/*
 
 test:
   dind: true

--- a/.one-pipeline.yaml
+++ b/.one-pipeline.yaml
@@ -32,20 +32,20 @@ setup:
     // Update repo with Whitesource enabled
     GHE_TOKEN=$(get_env git-token)
     WHITESOURCE_GHE_REPO=$(get_env whitesource-ghe-repo | sed 's/https:\/\///')
-    REF_SRC="refs/remotes/origin/$BRANCH"
 
-    if [[ -f ".git/refs/remotes/origin/$BRANCH" ]];
+    if [[ -f ".git/refs/remotes/origin/$BRANCH" ]]; then
       echo "Pushing branch $BRANCH to $WHITESOURCE_GHE_REPO"
-    elif [[ -f ".git/refs/tags/$BRANCH" ]];
-      echo "The given 'branch' ($BRANCH) is a tag. Creating a branch from it for scanning."
-      git checkout -b "$BRANCH" "$BRANCH"
-      REF_SRC="$BRANCH"
+      REFS="+refs/remotes/origin/$BRANCH:refs/heads/$BRANCH +refs/tags/*:refs/tags/*"
+    elif [[ -f ".git/refs/tags/$BRANCH" ]]; then
+      echo "The given 'branch' ($BRANCH) is a tag. Pushing it to $WHITESOURCE_GHE_REPO."
+      REFS="+refs/tags/$BRANCH:refs/tags/$BRANCH"
     else
       echo "Warning: Could not find a matching branch or tag named '$BRANCH'. Trying anyway!"
+      REFS="+refs/remotes/origin/$BRANCH:refs/heads/$BRANCH +refs/tags/*:refs/tags/*"
     fi
 
-    echo "git push --prune https://$GHE_TOKEN@$WHITESOURCE_GHE_REPO +"$REF_SRC":refs/heads/$BRANCH +refs/tags/*:refs/tags/*"
-    git push --prune https://$GHE_TOKEN@$WHITESOURCE_GHE_REPO +"$REF_SRC":refs/heads/$BRANCH +refs/tags/*:refs/tags/*
+    echo "git push --prune https://$GHE_TOKEN@$WHITESOURCE_GHE_REPO $REFS"
+    git push --prune https://$GHE_TOKEN@$WHITESOURCE_GHE_REPO "$REFS"
 
 test:
   dind: true

--- a/.one-pipeline.yaml
+++ b/.one-pipeline.yaml
@@ -32,19 +32,19 @@ setup:
     // Update repo with Whitesource enabled
     GHE_TOKEN=$(get_env git-token)
     WHITESOURCE_GHE_REPO=$(get_env whitesource-ghe-repo | sed 's/https:\/\///')
-    REF="+refs/remotes/origin/$BRANCH:refs/heads/$BRANCH"
+    BRANCH_REFSPEC="+refs/remotes/origin/$BRANCH:refs/heads/$BRANCH"
 
     if [[ -n "$(git branch --list -r origin/$BRANCH)" ]]; then
       echo "Pushing branch $BRANCH to $WHITESOURCE_GHE_REPO"
     elif [[ -n "$(git tag --list $BRANCH)" ]]; then
       echo "The given 'branch' ($BRANCH) is a tag. Pushing only tags to $WHITESOURCE_GHE_REPO."
-      REF=""
+      BRANCH_REFSPEC=""
     else
       echo "Warning: Could not find a matching branch or tag named '$BRANCH'. Trying anyway!"
     fi
 
-    echo "git push --prune https://$GHE_TOKEN@$WHITESOURCE_GHE_REPO $REF +refs/tags/*:refs/tags/*"
-    git push --prune https://$GHE_TOKEN@$WHITESOURCE_GHE_REPO "$REF" +refs/tags/*:refs/tags/*
+    echo "git push --prune https://$GHE_TOKEN@$WHITESOURCE_GHE_REPO $BRANCH_REFSPEC +refs/tags/*:refs/tags/*"
+    git push --prune https://$GHE_TOKEN@$WHITESOURCE_GHE_REPO "$BRANCH_REFSPEC" +refs/tags/*:refs/tags/*
 
 test:
   dind: true

--- a/.one-pipeline.yaml
+++ b/.one-pipeline.yaml
@@ -32,20 +32,19 @@ setup:
     // Update repo with Whitesource enabled
     GHE_TOKEN=$(get_env git-token)
     WHITESOURCE_GHE_REPO=$(get_env whitesource-ghe-repo | sed 's/https:\/\///')
+    REF="+refs/remotes/origin/$BRANCH:refs/heads/$BRANCH"
 
     if [[ -n "$(git branch --list -r origin/$BRANCH)" ]]; then
       echo "Pushing branch $BRANCH to $WHITESOURCE_GHE_REPO"
-      REFS="+refs/remotes/origin/$BRANCH:refs/heads/$BRANCH +refs/tags/*:refs/tags/*"
     elif [[ -n "$(git tag --list $BRANCH)" ]]; then
-      echo "The given 'branch' ($BRANCH) is a tag. Pushing it to $WHITESOURCE_GHE_REPO."
-      REFS="+refs/tags/$BRANCH:refs/tags/$BRANCH"
+      echo "The given 'branch' ($BRANCH) is a tag. Pushing only tags to $WHITESOURCE_GHE_REPO."
+      REF=""
     else
       echo "Warning: Could not find a matching branch or tag named '$BRANCH'. Trying anyway!"
-      REFS="+refs/remotes/origin/$BRANCH:refs/heads/$BRANCH +refs/tags/*:refs/tags/*"
     fi
 
-    echo "git push --prune https://$GHE_TOKEN@$WHITESOURCE_GHE_REPO $REFS"
-    git push --prune https://$GHE_TOKEN@$WHITESOURCE_GHE_REPO "$REFS"
+    echo "git push --prune https://$GHE_TOKEN@$WHITESOURCE_GHE_REPO $REF +refs/tags/*:refs/tags/*"
+    git push --prune https://$GHE_TOKEN@$WHITESOURCE_GHE_REPO "$REF" +refs/tags/*:refs/tags/*
 
 test:
   dind: true


### PR DESCRIPTION
We noticed an issue when running the CI pipeline with `branch` set to a pre-release (tag):
```
git push --prune https://****@github.ibm.com/websphere-compliance/websphere-liberty-operator-whitesource-scan.git +refs/remotes/origin/1.0.0-20220518-1830:refs/heads/1.0.0-20220518-1830 +refs/tags/*:refs/tags/*
error: src refspec refs/remotes/origin/1.0.0-20220518-1830 does not match any.
error: failed to push some refs to 'https://****@github.ibm.com/websphere-compliance/websphere-liberty-operator-whitesource-scan.git'

 === Execution of custom script for stage 'setup' finished. Exit Code: '1'. ===
```
This error was caused by the `git push` command trying to use the refspec `refs/remotes/origin/$BRANCH` when the "branch" was actually a tag. I added some logic to determine whether the given `branch` is a branch or a tag, and use the appropriate refspec in the `git push` command.