### PR TITLE
Update affinity tests

### DIFF
--- a/bundle/tests/scorecard/kuttl/affinity/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/affinity/00-assert.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: affinity-rc
+  name: affinity-rc-labels
 spec:
   template:
     spec:

--- a/bundle/tests/scorecard/kuttl/affinity/00-errors.yaml
+++ b/bundle/tests/scorecard/kuttl/affinity/00-errors.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: affinity-rc
+  name: affinity-rc-labels
 spec:
 status:
   readyReplicas: 1

--- a/bundle/tests/scorecard/kuttl/affinity/00-node-no-affinity.yaml
+++ b/bundle/tests/scorecard/kuttl/affinity/00-node-no-affinity.yaml
@@ -2,7 +2,7 @@
 apiVersion: liberty.websphere.ibm.com/v1
 kind: WebSphereLibertyApplication
 metadata:
-  name: affinity-rc
+  name: affinity-rc-labels
 spec:
   license:
     accept: true

--- a/bundle/tests/scorecard/kuttl/affinity/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/affinity/01-assert.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: affinity-rc
+  name: affinity-rc-labels
 spec:
   template:
     spec:
@@ -34,7 +34,7 @@ spec:
                   - key: app.kubernetes.io/instance
                     operator: In
                     values:
-                      - affinity-rc
+                      - affinity-rc-labels
               topologyKey: kubernetes.io/hostname
 status:
   replicas: 1

--- a/bundle/tests/scorecard/kuttl/affinity/01-node-pod-affinity.yaml
+++ b/bundle/tests/scorecard/kuttl/affinity/01-node-pod-affinity.yaml
@@ -2,7 +2,7 @@
 apiVersion: liberty.websphere.ibm.com/v1
 kind: WebSphereLibertyApplication
 metadata:
-  name: affinity-rc
+  name: affinity-rc-labels
 spec:
   license:
     accept: true
@@ -30,7 +30,7 @@ spec:
               - key: app.kubernetes.io/instance
                 operator: In
                 values:
-                  - affinity-rc
+                  - affinity-rc-labels
           topologyKey: kubernetes.io/hostname
   statefulSet:
     storage:

--- a/bundle/tests/scorecard/kuttl/affinity/02-errors.yaml
+++ b/bundle/tests/scorecard/kuttl/affinity/02-errors.yaml
@@ -1,4 +1,4 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: affinity-other-rc

--- a/bundle/tests/scorecard/kuttl/affinity/03-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/affinity/03-assert.yaml
@@ -15,7 +15,7 @@ spec:
                     - key: app.kubernetes.io/instance
                       operator: In
                       values:
-                        - affinity-rc
+                        - affinity-rc-labels
                 topologyKey: kubernetes.io/hostname
 status:
   replicas: 1

--- a/bundle/tests/scorecard/kuttl/affinity/03-pod-anti-affinity.yaml
+++ b/bundle/tests/scorecard/kuttl/affinity/03-pod-anti-affinity.yaml
@@ -18,5 +18,5 @@ spec:
             - key: app.kubernetes.io/instance
               operator: In
               values:
-                - affinity-rc
+                - affinity-rc-labels
           topologyKey: kubernetes.io/hostname

--- a/bundle/tests/scorecard/kuttl/affinity/04-delete.yaml
+++ b/bundle/tests/scorecard/kuttl/affinity/04-delete.yaml
@@ -3,7 +3,7 @@ kind: TestStep
 delete:
   - apiVersion: liberty.websphere.ibm.com/v1
     kind: WebSphereLibertyApplication
-    name: affinity-rc
+    name: affinity-rc-labels
   - apiVersion: liberty.websphere.ibm.com/v1
     kind: WebSphereLibertyApplication
     name: anti-affinity-rc

--- a/bundle/tests/scorecard/kuttl/affinity/04-errors.yaml
+++ b/bundle/tests/scorecard/kuttl/affinity/04-errors.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: affinity-rc
+  name: affinity-rc-labels
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go v0.84.0 h1:hVhK90DwCdOAYGME/FJd9vNIZye9HBR6Yy3fu4js3N8=
 cloud.google.com/go v0.84.0/go.mod h1:RazrYuxIK6Kb7YrzzhPoLmCVzl7Sup4NrbKPg8KHSUM=
-github.com/application-stacks/runtime-component-operator v0.8.1-0.20220520151143-aea6a777e569 h1:tyij3srJdJ48qvtVctM5T7AtIoNDyw34FeYApp2i2TQ=
-github.com/application-stacks/runtime-component-operator v0.8.1-0.20220520151143-aea6a777e569/go.mod h1:24Ta704BsAaUujWux37+m8iKiMi7o6ukPbtt43HLxQk=
+github.com/application-stacks/runtime-component-operator v0.8.1-0.20220520201747-a1fd7511d9f3 h1:G3+8KbUGZSzPCbQiGySAF22vcTIh9CDwIdzdEo8/i0w=
+github.com/application-stacks/runtime-component-operator v0.8.1-0.20220520201747-a1fd7511d9f3/go.mod h1:24Ta704BsAaUujWux37+m8iKiMi7o6ukPbtt43HLxQk=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=


### PR DESCRIPTION
Affinity tests were failing due to ReplicaSet revision history. As a result multiple replica sets were trying to create Pods, resulting in mismatch of 'replicas'. This is primarily caused by 04-delete. Change the CR name prior to it to avoid this issue. 