### PR TITLE
Make the tt binary executable

### DIFF
--- a/scripts/pipeline/twistlock-scan.sh
+++ b/scripts/pipeline/twistlock-scan.sh
@@ -9,6 +9,7 @@
     # Install 'tt' - Twistlock service cli
     wget --no-check-certificate https://w3twistlock.sos.ibm.com/download/tt_latest.zip && \
     unzip -l tt_latest.zip | grep linux_x86_64/tt | awk '{print $4}' | xargs unzip -j tt_latest.zip -d /usr/local/bin
+    chmod +x /usr/local/bin/tt
 }
 
 # Install Twistlock


### PR DESCRIPTION
After updating the URL from which we download the Twistlock tool `tt` we also needed to make that binary executable (previously it was already executable when unzipped). 