### PR TITLE
Enable multiple install modes when running e2e tests in Onepipeline

### DIFF
--- a/.one-pipeline.yaml
+++ b/.one-pipeline.yaml
@@ -253,6 +253,7 @@ acceptance-test:
     export TRAVIS_BUILD_NUMBER=$BUILD_NUMBER
     export RELEASE_TARGET=$(get_env branch)
     export CATALOG_IMAGE="$PIPELINE_REGISTRY/$PIPELINE_OPERATOR_IMAGE-catalog:$RELEASE_TARGET"
+    export INSTALL_MODE=$(get_env install-mode)
     make setup
     make test-pipeline-e2e
 

--- a/Makefile
+++ b/Makefile
@@ -289,7 +289,8 @@ test-pipeline-e2e:
                      --cluster-url "${CLUSTER_URL}" --cluster-user "${CLUSTER_USER}" --cluster-token "${CLUSTER_TOKEN}" \
                      --registry-name "${PIPELINE_REGISTRY}" --registry-image "${PIPELINE_OPERATOR_IMAGE}" \
                      --registry-user "${PIPELINE_USERNAME}" --registry-password "${PIPELINE_PASSWORD}" \
-                     --test-tag "${TRAVIS_BUILD_NUMBER}" --release "${RELEASE_TARGET}" --channel "${DEFAULT_CHANNEL}"
+                     --test-tag "${TRAVIS_BUILD_NUMBER}" --release "${RELEASE_TARGET}" --channel "${DEFAULT_CHANNEL}" \
+                     --install-mode "${INSTALL_MODE}"
 
 build-releases:
 	./scripts/build-releases.sh --image "${PUBLISH_REGISTRY}/${OPERATOR_IMAGE}" --target "${RELEASE_TARGET}"


### PR DESCRIPTION
- Update frye-e2e.sh script to allow the e2e tests to be run with different install modes

Signed-off-by: Jason Yong <jason_yong@uk.ibm.com>