### PR TITLE
Fix e2e runner names

### DIFF
--- a/scripts/acceptance-test.sh
+++ b/scripts/acceptance-test.sh
@@ -63,9 +63,15 @@ echo "****** Waiting for e2e tests to finish"
 for test in "${!E2E_TESTS[@]}"; do
 	test_name="${test}-${BUILD_NUMBER}"
 	until docker ps --all --no-trunc --filter name="^/${test_name}$" --format='{{.Status}}' | grep -q Exited; do
+		echo "Waiting for ${test_name} to finish..."
 		sleep 60
 	done
 	echo "${test_name} finished"
+done
+
+for test in "${!E2E_TESTS[@]}"; do
+	test_name="${test}-${BUILD_NUMBER}"
+	echo "****** Test logs for ${test_name}"
 	docker logs "${test_name}"
 done
 

--- a/scripts/e2e-kind.sh
+++ b/scripts/e2e-kind.sh
@@ -223,7 +223,6 @@ cleanup() {
     mv bundle/tests/scorecard/kind-kuttl/routes bundle/tests/scorecard/kuttl/
     mv bundle/tests/scorecard/kind-kuttl/route-certificate bundle/tests/scorecard/kuttl/
     mv bundle/tests/scorecard/kind-kuttl/image-stream bundle/tests/scorecard/kuttl/
-    mv bundle/tests/scorecard/kind-kuttl/stream bundle/tests/scorecard/kuttl/
 
     git checkout bundle/tests/scorecard internal/deploy
 }

--- a/scripts/e2e-minikube.sh
+++ b/scripts/e2e-minikube.sh
@@ -84,7 +84,6 @@ cleanup() {
     mv bundle/tests/scorecard/kind-kuttl/routes bundle/tests/scorecard/kuttl/
     mv bundle/tests/scorecard/kind-kuttl/route-certificate bundle/tests/scorecard/kuttl/
     mv bundle/tests/scorecard/kind-kuttl/image-stream bundle/tests/scorecard/kuttl/
-    mv bundle/tests/scorecard/kind-kuttl/stream bundle/tests/scorecard/kuttl/
 
     git checkout bundle/tests/scorecard internal/deploy
 


### PR DESCRIPTION
Use different names for the e2e runner to prevent issues with multiple pipeline runs.