### PR TITLE
Enable the Semeru Compiler to share cached ROM classes

### DIFF
--- a/controllers/semeru_compiler.go
+++ b/controllers/semeru_compiler.go
@@ -397,7 +397,7 @@ func getSemeruJavaOptions(instance *wlv1.WebSphereLibertyApplication) []string {
 			certificateLocation = "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
 		}
 		jitServerAddress := instance.Status.SemeruCompiler.ServiceHostname
-		jitSeverOptions := fmt.Sprintf("-XX:+UseJITServer -XX:+JITServerLogConnections -XX:JITServerAddress=%v -XX:JITServerSSLRootCerts=%v",
+		jitSeverOptions := fmt.Sprintf("-XX:+UseJITServer -XX:+JITServerLogConnections -XX:+JITServerShareROMClasses -XX:JITServerAddress=%v -XX:JITServerSSLRootCerts=%v",
 			jitServerAddress, certificateLocation)
 
 		args := []string{


### PR DESCRIPTION
Enable the Semeru compiler to share cached ROM classes between the Semeru clients

https://www.eclipse.org/openj9/docs/xxjitservershareromclasses/