### PR TITLE
Enablement of Semeru Cloud Compiler and UI updates for it

### DIFF
--- a/api/v1/webspherelibertyapplication_types.go
+++ b/api/v1/webspherelibertyapplication_types.go
@@ -99,7 +99,7 @@ type WebSphereLibertyApplicationSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:order=16,type=spec,displayName="Route"
 	Route *WebSphereLibertyApplicationRoute `json:"route,omitempty"`
 
-	// Enablement ond resource configuration of the Semeru Cloud Compiler
+	// Configures the Semeru Cloud Compiler.
 	// +operator-sdk:csv:customresourcedefinitions:order=17,type=spec,displayName="Semeru Cloud Compiler"
 	SemeruCloudCompiler *WebSphereLibertyApplicationSemeruCloudCompiler `json:"semeruCloudCompiler,omitempty"`
 
@@ -434,8 +434,8 @@ type WebSphereLibertyApplicationRoute struct {
 }
 
 type WebSphereLibertyApplicationSemeruCloudCompiler struct {
-	// Enables the Semeru Cloud Compiler. Defaults to false
-	// +operator-sdk:csv:customresourcedefinitions:order=52,type=spec,displayName="Enable Semeru Cloud Compiler",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:checkbox"}
+	// Enable the Semeru Cloud Compiler. Defaults to false.
+	// +operator-sdk:csv:customresourcedefinitions:order=52,type=spec,displayName="Enable",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	Enable bool `json:"enable,omitempty"`
 	// Resource requests and limits for the Semeru Cloud Compiler.
 	// +operator-sdk:csv:customresourcedefinitions:order=53,type=spec,displayName="Resource Requirements",xDescriptors="urn:alm:descriptor:com.tectonic.ui:resourceRequirements"

--- a/api/v1/webspherelibertyapplication_types.go
+++ b/api/v1/webspherelibertyapplication_types.go
@@ -99,7 +99,7 @@ type WebSphereLibertyApplicationSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:order=16,type=spec,displayName="Route"
 	Route *WebSphereLibertyApplicationRoute `json:"route,omitempty"`
 
-	// Configures the Semeru Cloud Compiler.
+	// Configures the Semeru Cloud Compiler to handle Just-In-Time (JIT) compilation requests from the application.
 	// +operator-sdk:csv:customresourcedefinitions:order=17,type=spec,displayName="Semeru Cloud Compiler"
 	SemeruCloudCompiler *WebSphereLibertyApplicationSemeruCloudCompiler `json:"semeruCloudCompiler,omitempty"`
 

--- a/api/v1/webspherelibertyapplication_types.go
+++ b/api/v1/webspherelibertyapplication_types.go
@@ -99,61 +99,62 @@ type WebSphereLibertyApplicationSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:order=16,type=spec,displayName="Route"
 	Route *WebSphereLibertyApplicationRoute `json:"route,omitempty"`
 
-	// +operator-sdk:csv:customresourcedefinitions:order=17,type=spec,displayName="Network Policy"
+	// Enablement ond resource configuration of the Semeru Cloud Compiler
+	// +operator-sdk:csv:customresourcedefinitions:order=17,type=spec,displayName="Semeru Cloud Compiler"
+	SemeruCloudCompiler *WebSphereLibertyApplicationSemeruCloudCompiler `json:"semeruCloudCompiler,omitempty"`
+
+	// +operator-sdk:csv:customresourcedefinitions:order=18,type=spec,displayName="Network Policy"
 	NetworkPolicy *WebSphereLibertyApplicationNetworkPolicy `json:"networkPolicy,omitempty"`
 
-	// +operator-sdk:csv:customresourcedefinitions:order=18,type=spec,displayName="Serviceability"
+	// +operator-sdk:csv:customresourcedefinitions:order=19,type=spec,displayName="Serviceability"
 	Serviceability *WebSphereLibertyApplicationServiceability `json:"serviceability,omitempty"`
 
-	// +operator-sdk:csv:customresourcedefinitions:order=19,type=spec,displayName="Single Sign-On"
+	// +operator-sdk:csv:customresourcedefinitions:order=20,type=spec,displayName="Single Sign-On"
 	SSO *WebSphereLibertyApplicationSSO `json:"sso,omitempty"`
 
-	// +operator-sdk:csv:customresourcedefinitions:order=20,type=spec,displayName="Monitoring"
+	// +operator-sdk:csv:customresourcedefinitions:order=21,type=spec,displayName="Monitoring"
 	Monitoring *WebSphereLibertyApplicationMonitoring `json:"monitoring,omitempty"`
 
 	// An array of environment variables for the application container.
 	// +listType=map
 	// +listMapKey=name
-	// +operator-sdk:csv:customresourcedefinitions:order=21,type=spec,displayName="Environment Variables"
+	// +operator-sdk:csv:customresourcedefinitions:order=22,type=spec,displayName="Environment Variables"
 	Env []corev1.EnvVar `json:"env,omitempty"`
 
 	// List of sources to populate environment variables in the application container.
 	// +listType=atomic
-	// +operator-sdk:csv:customresourcedefinitions:order=22,type=spec,displayName="Environment Variables from Sources"
+	// +operator-sdk:csv:customresourcedefinitions:order=23,type=spec,displayName="Environment Variables from Sources"
 	EnvFrom []corev1.EnvFromSource `json:"envFrom,omitempty"`
 
 	// Represents a volume with data that is accessible to the application container.
 	// +listType=map
 	// +listMapKey=name
-	// +operator-sdk:csv:customresourcedefinitions:order=23,type=spec,displayName="Volumes"
+	// +operator-sdk:csv:customresourcedefinitions:order=24,type=spec,displayName="Volumes"
 	Volumes []corev1.Volume `json:"volumes,omitempty"`
 
 	// Represents where to mount the volumes into the application container.
 	// +listType=atomic
-	// +operator-sdk:csv:customresourcedefinitions:order=24,type=spec,displayName="Volume Mounts"
+	// +operator-sdk:csv:customresourcedefinitions:order=25,type=spec,displayName="Volume Mounts"
 	VolumeMounts []corev1.VolumeMount `json:"volumeMounts,omitempty"`
 
 	// List of containers to run before other containers in a pod.
 	// +listType=map
 	// +listMapKey=name
-	// +operator-sdk:csv:customresourcedefinitions:order=25,type=spec,displayName="Init Containers"
+	// +operator-sdk:csv:customresourcedefinitions:order=26,type=spec,displayName="Init Containers"
 	InitContainers []corev1.Container `json:"initContainers,omitempty"`
 
 	// List of sidecar containers. These are additional containers to be added to the pods.
 	// +listType=map
 	// +listMapKey=name
-	// +operator-sdk:csv:customresourcedefinitions:order=26,type=spec,displayName="Sidecar Containers"
+	// +operator-sdk:csv:customresourcedefinitions:order=27,type=spec,displayName="Sidecar Containers"
 	SidecarContainers []corev1.Container `json:"sidecarContainers,omitempty"`
 
-	// +operator-sdk:csv:customresourcedefinitions:order=27,type=spec,displayName="Affinity"
+	// +operator-sdk:csv:customresourcedefinitions:order=28,type=spec,displayName="Affinity"
 	Affinity *WebSphereLibertyApplicationAffinity `json:"affinity,omitempty"`
 
 	// Security context for the application container.
-	// +operator-sdk:csv:customresourcedefinitions:order=28,type=spec,displayName="Security Context"
+	// +operator-sdk:csv:customresourcedefinitions:order=29,type=spec,displayName="Security Context"
 	SecurityContext *corev1.SecurityContext `json:"securityContext,omitempty"`
-
-	// +operator-sdk:csv:customresourcedefinitions:order=29,type=spec,displayName="Semeru Cloud Compiler"
-	SemeruCloudCompiler *WebSphereLibertyApplicationSemeruCloudCompiler `json:"semeruCloudCompiler,omitempty"`
 }
 
 // License information is required.
@@ -433,8 +434,11 @@ type WebSphereLibertyApplicationRoute struct {
 }
 
 type WebSphereLibertyApplicationSemeruCloudCompiler struct {
+	// Enables the Semeru Cloud Compiler. Defaults to false
+	// +operator-sdk:csv:customresourcedefinitions:order=52,type=spec,displayName="Enable Semeru Cloud Compiler",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:checkbox"}
+	Enable bool `json:"enable,omitempty"`
 	// Resource requests and limits for the Semeru Cloud Compiler.
-	// +operator-sdk:csv:customresourcedefinitions:order=48,type=spec,displayName="Resource Requirements",xDescriptors="urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+	// +operator-sdk:csv:customresourcedefinitions:order=53,type=spec,displayName="Resource Requirements",xDescriptors="urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 }
 

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -747,6 +747,11 @@ func (in *WebSphereLibertyApplicationSpec) DeepCopyInto(out *WebSphereLibertyApp
 		*out = new(WebSphereLibertyApplicationRoute)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.SemeruCloudCompiler != nil {
+		in, out := &in.SemeruCloudCompiler, &out.SemeruCloudCompiler
+		*out = new(WebSphereLibertyApplicationSemeruCloudCompiler)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.NetworkPolicy != nil {
 		in, out := &in.NetworkPolicy, &out.NetworkPolicy
 		*out = new(WebSphereLibertyApplicationNetworkPolicy)
@@ -817,11 +822,6 @@ func (in *WebSphereLibertyApplicationSpec) DeepCopyInto(out *WebSphereLibertyApp
 	if in.SecurityContext != nil {
 		in, out := &in.SecurityContext, &out.SecurityContext
 		*out = new(corev1.SecurityContext)
-		(*in).DeepCopyInto(*out)
-	}
-	if in.SemeruCloudCompiler != nil {
-		in, out := &in.SemeruCloudCompiler, &out.SemeruCloudCompiler
-		*out = new(WebSphereLibertyApplicationSemeruCloudCompiler)
 		(*in).DeepCopyInto(*out)
 	}
 }

--- a/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
@@ -58,7 +58,7 @@ metadata:
     capabilities: Auto Pilot
     categories: Application Runtime
     containerImage: icr.io/cpopen/websphere-liberty-operator:daily
-    createdAt: "2022-11-16T16:22:52Z"
+    createdAt: "2022-11-16T16:35:49Z"
     description: Deploy and manage containerized Liberty applications
     olm.skipRange: '>=1.0.0 <1.1.0'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
@@ -276,7 +276,7 @@ spec:
       - description: An array consisting of service ports.
         displayName: Ports
         path: service.ports
-      - description: Configures the Semeru Cloud Compiler.
+      - description: Configures the Semeru Cloud Compiler to handle Just-In-Time (JIT) compilation requests from the application.
         displayName: Semeru Cloud Compiler
         path: semeruCloudCompiler
       - description: Expose the application as a bindable service. Defaults to false.

--- a/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
@@ -58,7 +58,7 @@ metadata:
     capabilities: Auto Pilot
     categories: Application Runtime
     containerImage: icr.io/cpopen/websphere-liberty-operator:daily
-    createdAt: "2022-11-16T11:43:17Z"
+    createdAt: "2022-11-16T16:22:52Z"
     description: Deploy and manage containerized Liberty applications
     olm.skipRange: '>=1.0.0 <1.1.0'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
@@ -276,7 +276,7 @@ spec:
       - description: An array consisting of service ports.
         displayName: Ports
         path: service.ports
-      - description: Enablement ond resource configuration of the Semeru Cloud Compiler
+      - description: Configures the Semeru Cloud Compiler.
         displayName: Semeru Cloud Compiler
         path: semeruCloudCompiler
       - description: Expose the application as a bindable service. Defaults to false.
@@ -430,11 +430,11 @@ spec:
         path: networkPolicy.disable
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: Enables the Semeru Cloud Compiler. Defaults to false
-        displayName: Enable Semeru Cloud Compiler
+      - description: Enable the Semeru Cloud Compiler. Defaults to false.
+        displayName: Enable
         path: semeruCloudCompiler.enable
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:checkbox
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specify the labels of namespaces that incoming traffic is allowed from.
         displayName: Namespace Labels
         path: networkPolicy.namespaceLabels

--- a/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
@@ -58,7 +58,7 @@ metadata:
     capabilities: Auto Pilot
     categories: Application Runtime
     containerImage: icr.io/cpopen/websphere-liberty-operator:daily
-    createdAt: "2022-11-02T16:48:47Z"
+    createdAt: "2022-11-16T11:43:17Z"
     description: Deploy and manage containerized Liberty applications
     olm.skipRange: '>=1.0.0 <1.1.0'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
@@ -276,24 +276,27 @@ spec:
       - description: An array consisting of service ports.
         displayName: Ports
         path: service.ports
-      - displayName: Network Policy
-        path: networkPolicy
+      - description: Enablement ond resource configuration of the Semeru Cloud Compiler
+        displayName: Semeru Cloud Compiler
+        path: semeruCloudCompiler
       - description: Expose the application as a bindable service. Defaults to false.
         displayName: Bindable
         path: service.bindable
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - displayName: Network Policy
+        path: networkPolicy
       - displayName: Serviceability
         path: serviceability
       - displayName: Single Sign-On
         path: sso
-      - displayName: Monitoring
-        path: monitoring
       - description: Specifies the strategy to replace old deployment pods with new pods.
         displayName: Deployment Update Strategy
         path: deployment.updateStrategy
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:updateStrategy
+      - displayName: Monitoring
+        path: monitoring
       - description: An array of environment variables for the application container.
         displayName: Environment Variables
         path: env
@@ -303,47 +306,45 @@ spec:
       - description: Specifies the strategy to replace old StatefulSet pods with new pods.
         displayName: StatefulSet Update Strategy
         path: statefulSet.updateStrategy
+      - displayName: Storage
+        path: statefulSet.storage
       - description: Represents a volume with data that is accessible to the application container.
         displayName: Volumes
         path: volumes
-      - displayName: Storage
-        path: statefulSet.storage
+      - description: A convenient field to set the size of the persisted storage.
+        displayName: Storage Size
+        path: statefulSet.storage.size
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: Represents where to mount the volumes into the application container.
         displayName: Volume Mounts
         path: volumeMounts
       - description: List of containers to run before other containers in a pod.
         displayName: Init Containers
         path: initContainers
-      - description: A convenient field to set the size of the persisted storage.
-        displayName: Storage Size
-        path: statefulSet.storage.size
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: List of sidecar containers. These are additional containers to be added to the pods.
-        displayName: Sidecar Containers
-        path: sidecarContainers
       - description: A convenient field to request the storage class of the persisted storage. The name can not be specified or updated after the storage is created.
         displayName: Storage Class Name
         path: statefulSet.storage.className
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - displayName: Affinity
-        path: affinity
+      - description: List of sidecar containers. These are additional containers to be added to the pods.
+        displayName: Sidecar Containers
+        path: sidecarContainers
       - description: The directory inside the container where this persisted storage will be bound to.
         displayName: Storage Mount Path
         path: statefulSet.storage.mountPath
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Security context for the application container.
-        displayName: Security Context
-        path: securityContext
+      - displayName: Affinity
+        path: affinity
       - description: A YAML object that represents a volumeClaimTemplate component of a StatefulSet.
         displayName: Storage Volume Claim Template
         path: statefulSet.storage.volumeClaimTemplate
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:PersistentVolumeClaim
-      - displayName: Semeru Cloud Compiler
-        path: semeruCloudCompiler
+      - description: Security context for the application container.
+        displayName: Security Context
+        path: securityContext
       - description: Labels to set on ServiceMonitor.
         displayName: Monitoring Labels
         path: monitoring.labels
@@ -415,11 +416,6 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:select:Allow
         - urn:alm:descriptor:com.tectonic.ui:select:Redirect
         - urn:alm:descriptor:com.tectonic.ui:select:None
-      - description: Resource requests and limits for the Semeru Cloud Compiler.
-        displayName: Resource Requirements
-        path: semeruCloudCompiler.resources
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - description: Periodic probe of container liveness. Container will be restarted if the probe fails.
         displayName: Liveness Probe
         path: probes.liveness
@@ -434,11 +430,21 @@ spec:
         path: networkPolicy.disable
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Enables the Semeru Cloud Compiler. Defaults to false
+        displayName: Enable Semeru Cloud Compiler
+        path: semeruCloudCompiler.enable
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:checkbox
       - description: Specify the labels of namespaces that incoming traffic is allowed from.
         displayName: Namespace Labels
         path: networkPolicy.namespaceLabels
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Resource requests and limits for the Semeru Cloud Compiler.
+        displayName: Resource Requirements
+        path: semeruCloudCompiler.resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - description: Specify the labels of pod(s) that incoming traffic is allowed from.
         displayName: From Labels
         path: networkPolicy.fromLabels

--- a/bundle/manifests/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
+++ b/bundle/manifests/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
@@ -2397,7 +2397,11 @@ spec:
                     type: object
                 type: object
               semeruCloudCompiler:
+                description: Enablement ond resource configuration of the Semeru Cloud Compiler
                 properties:
+                  enable:
+                    description: Enables the Semeru Cloud Compiler. Defaults to false
+                    type: boolean
                   resources:
                     description: Resource requests and limits for the Semeru Cloud Compiler.
                     properties:

--- a/bundle/manifests/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
+++ b/bundle/manifests/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
@@ -2397,7 +2397,7 @@ spec:
                     type: object
                 type: object
               semeruCloudCompiler:
-                description: Configures the Semeru Cloud Compiler.
+                description: Configures the Semeru Cloud Compiler to handle Just-In-Time (JIT) compilation requests from the application.
                 properties:
                   enable:
                     description: Enable the Semeru Cloud Compiler. Defaults to false.

--- a/bundle/manifests/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
+++ b/bundle/manifests/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
@@ -2397,10 +2397,10 @@ spec:
                     type: object
                 type: object
               semeruCloudCompiler:
-                description: Enablement ond resource configuration of the Semeru Cloud Compiler
+                description: Configures the Semeru Cloud Compiler.
                 properties:
                   enable:
-                    description: Enables the Semeru Cloud Compiler. Defaults to false
+                    description: Enable the Semeru Cloud Compiler. Defaults to false.
                     type: boolean
                   resources:
                     description: Resource requests and limits for the Semeru Cloud Compiler.

--- a/config/crd/bases/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
+++ b/config/crd/bases/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
@@ -3629,7 +3629,12 @@ spec:
                     type: object
                 type: object
               semeruCloudCompiler:
+                description: Enablement ond resource configuration of the Semeru Cloud
+                  Compiler
                 properties:
+                  enable:
+                    description: Enables the Semeru Cloud Compiler. Defaults to false
+                    type: boolean
                   resources:
                     description: Resource requests and limits for the Semeru Cloud
                       Compiler.

--- a/config/crd/bases/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
+++ b/config/crd/bases/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
@@ -3629,11 +3629,10 @@ spec:
                     type: object
                 type: object
               semeruCloudCompiler:
-                description: Enablement ond resource configuration of the Semeru Cloud
-                  Compiler
+                description: Configures the Semeru Cloud Compiler.
                 properties:
                   enable:
-                    description: Enables the Semeru Cloud Compiler. Defaults to false
+                    description: Enable the Semeru Cloud Compiler. Defaults to false.
                     type: boolean
                   resources:
                     description: Resource requests and limits for the Semeru Cloud

--- a/config/crd/bases/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
+++ b/config/crd/bases/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
@@ -3629,7 +3629,8 @@ spec:
                     type: object
                 type: object
               semeruCloudCompiler:
-                description: Configures the Semeru Cloud Compiler.
+                description: Configures the Semeru Cloud Compiler to handle Just-In-Time
+                  (JIT) compilation requests from the application.
                 properties:
                   enable:
                     description: Enable the Semeru Cloud Compiler. Defaults to false.

--- a/config/manifests/bases/ibm-websphere-liberty.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-websphere-liberty.clusterserviceversion.yaml
@@ -221,7 +221,7 @@ spec:
       - description: An array consisting of service ports.
         displayName: Ports
         path: service.ports
-      - description: Enablement ond resource configuration of the Semeru Cloud Compiler
+      - description: Configures the Semeru Cloud Compiler.
         displayName: Semeru Cloud Compiler
         path: semeruCloudCompiler
       - description: Expose the application as a bindable service. Defaults to false.
@@ -375,11 +375,11 @@ spec:
         path: networkPolicy.disable
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: Enables the Semeru Cloud Compiler. Defaults to false
-        displayName: Enable Semeru Cloud Compiler
+      - description: Enable the Semeru Cloud Compiler. Defaults to false.
+        displayName: Enable
         path: semeruCloudCompiler.enable
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:checkbox
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specify the labels of namespaces that incoming traffic is allowed from.
         displayName: Namespace Labels
         path: networkPolicy.namespaceLabels

--- a/config/manifests/bases/ibm-websphere-liberty.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-websphere-liberty.clusterserviceversion.yaml
@@ -221,24 +221,27 @@ spec:
       - description: An array consisting of service ports.
         displayName: Ports
         path: service.ports
-      - displayName: Network Policy
-        path: networkPolicy
+      - description: Enablement ond resource configuration of the Semeru Cloud Compiler
+        displayName: Semeru Cloud Compiler
+        path: semeruCloudCompiler
       - description: Expose the application as a bindable service. Defaults to false.
         displayName: Bindable
         path: service.bindable
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - displayName: Network Policy
+        path: networkPolicy
       - displayName: Serviceability
         path: serviceability
       - displayName: Single Sign-On
         path: sso
-      - displayName: Monitoring
-        path: monitoring
       - description: Specifies the strategy to replace old deployment pods with new pods.
         displayName: Deployment Update Strategy
         path: deployment.updateStrategy
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:updateStrategy
+      - displayName: Monitoring
+        path: monitoring
       - description: An array of environment variables for the application container.
         displayName: Environment Variables
         path: env
@@ -248,47 +251,45 @@ spec:
       - description: Specifies the strategy to replace old StatefulSet pods with new pods.
         displayName: StatefulSet Update Strategy
         path: statefulSet.updateStrategy
+      - displayName: Storage
+        path: statefulSet.storage
       - description: Represents a volume with data that is accessible to the application container.
         displayName: Volumes
         path: volumes
-      - displayName: Storage
-        path: statefulSet.storage
+      - description: A convenient field to set the size of the persisted storage.
+        displayName: Storage Size
+        path: statefulSet.storage.size
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: Represents where to mount the volumes into the application container.
         displayName: Volume Mounts
         path: volumeMounts
       - description: List of containers to run before other containers in a pod.
         displayName: Init Containers
         path: initContainers
-      - description: A convenient field to set the size of the persisted storage.
-        displayName: Storage Size
-        path: statefulSet.storage.size
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: List of sidecar containers. These are additional containers to be added to the pods.
-        displayName: Sidecar Containers
-        path: sidecarContainers
       - description: A convenient field to request the storage class of the persisted storage. The name can not be specified or updated after the storage is created.
         displayName: Storage Class Name
         path: statefulSet.storage.className
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - displayName: Affinity
-        path: affinity
+      - description: List of sidecar containers. These are additional containers to be added to the pods.
+        displayName: Sidecar Containers
+        path: sidecarContainers
       - description: The directory inside the container where this persisted storage will be bound to.
         displayName: Storage Mount Path
         path: statefulSet.storage.mountPath
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Security context for the application container.
-        displayName: Security Context
-        path: securityContext
+      - displayName: Affinity
+        path: affinity
       - description: A YAML object that represents a volumeClaimTemplate component of a StatefulSet.
         displayName: Storage Volume Claim Template
         path: statefulSet.storage.volumeClaimTemplate
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:PersistentVolumeClaim
-      - displayName: Semeru Cloud Compiler
-        path: semeruCloudCompiler
+      - description: Security context for the application container.
+        displayName: Security Context
+        path: securityContext
       - description: Labels to set on ServiceMonitor.
         displayName: Monitoring Labels
         path: monitoring.labels
@@ -360,11 +361,6 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:select:Allow
         - urn:alm:descriptor:com.tectonic.ui:select:Redirect
         - urn:alm:descriptor:com.tectonic.ui:select:None
-      - description: Resource requests and limits for the Semeru Cloud Compiler.
-        displayName: Resource Requirements
-        path: semeruCloudCompiler.resources
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - description: Periodic probe of container liveness. Container will be restarted if the probe fails.
         displayName: Liveness Probe
         path: probes.liveness
@@ -379,11 +375,21 @@ spec:
         path: networkPolicy.disable
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Enables the Semeru Cloud Compiler. Defaults to false
+        displayName: Enable Semeru Cloud Compiler
+        path: semeruCloudCompiler.enable
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:checkbox
       - description: Specify the labels of namespaces that incoming traffic is allowed from.
         displayName: Namespace Labels
         path: networkPolicy.namespaceLabels
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Resource requests and limits for the Semeru Cloud Compiler.
+        displayName: Resource Requirements
+        path: semeruCloudCompiler.resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - description: Specify the labels of pod(s) that incoming traffic is allowed from.
         displayName: From Labels
         path: networkPolicy.fromLabels

--- a/config/manifests/bases/ibm-websphere-liberty.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-websphere-liberty.clusterserviceversion.yaml
@@ -221,7 +221,7 @@ spec:
       - description: An array consisting of service ports.
         displayName: Ports
         path: service.ports
-      - description: Configures the Semeru Cloud Compiler.
+      - description: Configures the Semeru Cloud Compiler to handle Just-In-Time (JIT) compilation requests from the application.
         displayName: Semeru Cloud Compiler
         path: semeruCloudCompiler
       - description: Expose the application as a bindable service. Defaults to false.

--- a/controllers/webspherelibertyapplication_controller.go
+++ b/controllers/webspherelibertyapplication_controller.go
@@ -476,7 +476,7 @@ func (r *ReconcileWebSphereLiberty) Reconcile(ctx context.Context, request ctrl.
 			}
 			lutils.ConfigureServiceability(&statefulSet.Spec.Template, instance)
 			semeruCertVolume := getSemeruCertVolume(instance)
-			if semeruCertVolume != nil {
+			if r.isSemeruEnabled(instance) && semeruCertVolume != nil {
 				statefulSet.Spec.Template.Spec.Volumes = append(statefulSet.Spec.Template.Spec.Volumes, *semeruCertVolume)
 				statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts = append(statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts,
 					getSemeruCertVolumeMount(instance))
@@ -538,7 +538,7 @@ func (r *ReconcileWebSphereLiberty) Reconcile(ctx context.Context, request ctrl.
 
 			lutils.ConfigureServiceability(&deploy.Spec.Template, instance)
 			semeruCertVolume := getSemeruCertVolume(instance)
-			if semeruCertVolume != nil {
+			if r.isSemeruEnabled(instance) && semeruCertVolume != nil {
 				deploy.Spec.Template.Spec.Volumes = append(deploy.Spec.Template.Spec.Volumes, *semeruCertVolume)
 				deploy.Spec.Template.Spec.Containers[0].VolumeMounts = append(deploy.Spec.Template.Spec.Containers[0].VolumeMounts,
 					getSemeruCertVolumeMount(instance))

--- a/controllers/webspherelibertyapplication_controller.go
+++ b/controllers/webspherelibertyapplication_controller.go
@@ -276,13 +276,15 @@ func (r *ReconcileWebSphereLiberty) Reconcile(ctx context.Context, request ctrl.
 		return r.ManageError(err, common.StatusConditionTypeReconciled, instance)
 	}
 	// If semeru compiler is enabled, make sure its ready
-	message = "Check Semeru Compiler resources ready"
-	reqLogger.Info(message)
-	if instance.GetSemeruCloudCompiler() != nil {
-		err = r.areSemeruCompilerResourcesReady(instance)
-		if err != nil {
-			reqLogger.Error(err, message)
-			return r.ManageError(err, common.StatusConditionTypeResourcesReady, instance)
+	if r.isSemeruEnabled(instance) {
+		message = "Check Semeru Compiler resources ready"
+		reqLogger.Info(message)
+		if instance.GetSemeruCloudCompiler() != nil {
+			err = r.areSemeruCompilerResourcesReady(instance)
+			if err != nil {
+				reqLogger.Error(err, message)
+				return r.ManageError(err, common.StatusConditionTypeResourcesReady, instance)
+			}
 		}
 	}
 
@@ -503,7 +505,7 @@ func (r *ReconcileWebSphereLiberty) Reconcile(ctx context.Context, request ctrl.
 				reqLogger.Error(err, "Failed to reconcile Liberty env, error: "+err.Error())
 				return err
 			}
-			deploy.Spec.Template.Spec.Containers[0].Args = getSemeruJavaOptions(instance)
+			deploy.Spec.Template.Spec.Containers[0].Args = r.getSemeruJavaOptions(instance)
 
 			if err := oputils.CustomizePodWithSVCCertificate(&deploy.Spec.Template, instance, r.GetClient()); err != nil {
 				return err


### PR DESCRIPTION
* Add `.spec.semeruCloudCompiler.enable` and use to to check enablement of the Semeru Cloud Compiler
* Update the UI to add a checkbox for the enablement
* Re-arrange UI so that Semeru is higher up.
* For issue [323](https://github.com/WASdev/websphere-liberty-operator/issues/323)
Signed-off-by: Jason Yong <jason_yong@uk.ibm.com>