### PR TITLE
Add license annotations and change default resource req of Semeru compiler

### DIFF
--- a/api/v1/webspherelibertyapplication_types.go
+++ b/api/v1/webspherelibertyapplication_types.go
@@ -167,7 +167,7 @@ type License struct {
 	// +operator-sdk:csv:customresourcedefinitions:order=101,type=spec,displayName="Product Entitlement Source"
 	ProductEntitlementSource LicenseEntitlement `json:"productEntitlementSource,omitempty"`
 
-	// Charge metric code. Defaults to Virtual Processor Core (VPC). Other option: Processor Value Unit (PVU)
+	// Deprecated. Charge metric code is now automatically determined based on the specified product edition and entitlement source.
 	// +operator-sdk:csv:customresourcedefinitions:order=102,type=spec,displayName="Metric",xDescriptors="urn:alm:descriptor:com.tectonic.ui:hidden"
 	Metric LicenseMetric `json:"metric,omitempty"`
 

--- a/api/v1/webspherelibertyapplication_types.go
+++ b/api/v1/webspherelibertyapplication_types.go
@@ -440,7 +440,7 @@ type WebSphereLibertyApplicationSemeruCloudCompiler struct {
 	// Number of desired pods for the Semeru Cloud Compiler. Defaults to 1.
 	// +operator-sdk:csv:customresourcedefinitions:order=53,type=spec,displayName="Replicas",xDescriptors="urn:alm:descriptor:com.tectonic.ui:podCount"
 	Replicas *int32 `json:"replicas,omitempty"`
-	// Resource requests and limits for the Semeru Cloud Compiler.
+	// Resource requests and limits for the Semeru Cloud Compiler. The CPU defaults to 100m with a limit of 2000m. The memory defaults to 800Mi, with a limit of 1200Mi.
 	// +operator-sdk:csv:customresourcedefinitions:order=54,type=spec,displayName="Resource Requirements",xDescriptors="urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 }

--- a/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
@@ -57,7 +57,7 @@ metadata:
     capabilities: Auto Pilot
     categories: Application Runtime
     containerImage: icr.io/cpopen/websphere-liberty-operator:daily
-    createdAt: "2022-12-05T17:50:01Z"
+    createdAt: "2022-12-06T09:20:39Z"
     description: Deploy and manage containerized Liberty applications
     olm.skipRange: '>=1.0.0 <1.1.0'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
@@ -460,7 +460,7 @@ spec:
       - description: 'Entitlement source for the product. Defaults to Standalone. Other options: IBM Cloud Pak for Applications, IBM WebSphere Application Server Family Edition, IBM WebSphere Hybrid Edition'
         displayName: Product Entitlement Source
         path: license.productEntitlementSource
-      - description: 'Charge metric code. Defaults to Virtual Processor Core (VPC). Other option: Processor Value Unit (PVU)'
+      - description: Deprecated. Charge metric code is now automatically determined based on the specified product edition and entitlement source.
         displayName: Metric
         path: license.metric
         x-descriptors:

--- a/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
@@ -57,7 +57,7 @@ metadata:
     capabilities: Auto Pilot
     categories: Application Runtime
     containerImage: icr.io/cpopen/websphere-liberty-operator:daily
-    createdAt: "2022-11-29T10:35:44Z"
+    createdAt: "2022-12-05T17:50:01Z"
     description: Deploy and manage containerized Liberty applications
     olm.skipRange: '>=1.0.0 <1.1.0'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
@@ -449,7 +449,7 @@ spec:
         path: networkPolicy.fromLabels
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Resource requests and limits for the Semeru Cloud Compiler.
+      - description: Resource requests and limits for the Semeru Cloud Compiler. The CPU defaults to 100m with a limit of 2000m. The memory defaults to 800Mi, with a limit of 1200Mi.
         displayName: Resource Requirements
         path: semeruCloudCompiler.resources
         x-descriptors:

--- a/bundle/manifests/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
+++ b/bundle/manifests/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
@@ -1541,7 +1541,7 @@ spec:
                     - IBM WebSphere Application Server Network Deployment
                     type: string
                   metric:
-                    description: 'Charge metric code. Defaults to Virtual Processor Core (VPC). Other option: Processor Value Unit (PVU)'
+                    description: Deprecated. Charge metric code is now automatically determined based on the specified product edition and entitlement source.
                     enum:
                     - Virtual Processor Core (VPC)
                     - Processor Value Unit (PVU)

--- a/bundle/manifests/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
+++ b/bundle/manifests/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
@@ -2407,7 +2407,7 @@ spec:
                     format: int32
                     type: integer
                   resources:
-                    description: Resource requests and limits for the Semeru Cloud Compiler.
+                    description: Resource requests and limits for the Semeru Cloud Compiler. The CPU defaults to 100m with a limit of 2000m. The memory defaults to 800Mi, with a limit of 1200Mi.
                     properties:
                       limits:
                         additionalProperties:

--- a/config/crd/bases/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
+++ b/config/crd/bases/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
@@ -3642,7 +3642,8 @@ spec:
                     type: integer
                   resources:
                     description: Resource requests and limits for the Semeru Cloud
-                      Compiler.
+                      Compiler. The CPU defaults to 100m with a limit of 2000m. The
+                      memory defaults to 800Mi, with a limit of 1200Mi.
                     properties:
                       limits:
                         additionalProperties:

--- a/config/crd/bases/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
+++ b/config/crd/bases/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
@@ -2421,8 +2421,9 @@ spec:
                     - IBM WebSphere Application Server Network Deployment
                     type: string
                   metric:
-                    description: 'Charge metric code. Defaults to Virtual Processor
-                      Core (VPC). Other option: Processor Value Unit (PVU)'
+                    description: Deprecated. Charge metric code is now automatically
+                      determined based on the specified product edition and entitlement
+                      source.
                     enum:
                     - Virtual Processor Core (VPC)
                     - Processor Value Unit (PVU)

--- a/config/manifests/bases/ibm-websphere-liberty.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-websphere-liberty.clusterserviceversion.yaml
@@ -406,7 +406,7 @@ spec:
       - description: 'Entitlement source for the product. Defaults to Standalone. Other options: IBM Cloud Pak for Applications, IBM WebSphere Application Server Family Edition, IBM WebSphere Hybrid Edition'
         displayName: Product Entitlement Source
         path: license.productEntitlementSource
-      - description: 'Charge metric code. Defaults to Virtual Processor Core (VPC). Other option: Processor Value Unit (PVU)'
+      - description: Deprecated. Charge metric code is now automatically determined based on the specified product edition and entitlement source.
         displayName: Metric
         path: license.metric
         x-descriptors:

--- a/config/manifests/bases/ibm-websphere-liberty.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-websphere-liberty.clusterserviceversion.yaml
@@ -395,7 +395,7 @@ spec:
         path: networkPolicy.fromLabels
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Resource requests and limits for the Semeru Cloud Compiler.
+      - description: Resource requests and limits for the Semeru Cloud Compiler. The CPU defaults to 100m with a limit of 2000m. The memory defaults to 800Mi, with a limit of 1200Mi.
         displayName: Resource Requirements
         path: semeruCloudCompiler.resources
         x-descriptors:

--- a/controllers/semeru_compiler.go
+++ b/controllers/semeru_compiler.go
@@ -43,7 +43,6 @@ import (
 const (
 	SemeruLabelNameSuffix                   = "-semeru-compiler"
 	SemeruLabelName                         = "semeru-compiler"
-	JitServer                               = "jitserver"
 	SemeruGenerationLabelNameSuffix         = "/semeru-compiler-generation"
 	StatusReferenceSemeruGeneration         = "semeruGeneration"
 	StatusReferenceSemeruInstancesCompleted = "semeruInstancesCompleted"
@@ -298,7 +297,7 @@ func (r *ReconcileWebSphereLiberty) reconcileSemeruDeployment(wlva *wlv1.WebSphe
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
-					Name:            JitServer,
+					Name:            "compiler",
 					Image:           wlva.Status.GetImageReference(),
 					ImagePullPolicy: *wlva.GetPullPolicy(),
 					Command:         []string{"jitserver"},

--- a/controllers/semeru_compiler.go
+++ b/controllers/semeru_compiler.go
@@ -292,7 +292,8 @@ func (r *ReconcileWebSphereLiberty) reconcileSemeruDeployment(wlva *wlv1.WebSphe
 
 	deploy.Spec.Template = corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: getLabels(wlva),
+			Labels:      getLabels(wlva),
+			Annotations: wlutils.GetWLOLicenseAnnotations(),
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{

--- a/controllers/semeru_compiler.go
+++ b/controllers/semeru_compiler.go
@@ -263,10 +263,10 @@ func (r *ReconcileWebSphereLiberty) reconcileSemeruDeployment(wlva *wlv1.WebSphe
 	// Get Semeru resources config
 	instanceResources := semeruCloudCompiler.Resources
 
-	requestsMemory := getQuantityFromRequestsOrDefault(instanceResources, corev1.ResourceMemory, "1200Mi")
-	requestsCPU := getQuantityFromRequestsOrDefault(instanceResources, corev1.ResourceCPU, "1000m")
+	requestsMemory := getQuantityFromRequestsOrDefault(instanceResources, corev1.ResourceMemory, "800Mi")
+	requestsCPU := getQuantityFromRequestsOrDefault(instanceResources, corev1.ResourceCPU, "100m")
 	limitsMemory := getQuantityFromLimitsOrDefault(instanceResources, corev1.ResourceMemory, "1200Mi")
-	limitsCPU := getQuantityFromLimitsOrDefault(instanceResources, corev1.ResourceCPU, "8000m")
+	limitsCPU := getQuantityFromLimitsOrDefault(instanceResources, corev1.ResourceCPU, "2000m")
 
 	// Liveness probe
 	livenessProbe := corev1.Probe{

--- a/internal/deploy/kustomize/daily/base/websphere-liberty-crd.yaml
+++ b/internal/deploy/kustomize/daily/base/websphere-liberty-crd.yaml
@@ -2406,7 +2406,7 @@ spec:
                     format: int32
                     type: integer
                   resources:
-                    description: Resource requests and limits for the Semeru Cloud Compiler.
+                    description: Resource requests and limits for the Semeru Cloud Compiler. The CPU defaults to 100m with a limit of 2000m. The memory defaults to 800Mi, with a limit of 1200Mi.
                     properties:
                       limits:
                         additionalProperties:

--- a/internal/deploy/kustomize/daily/base/websphere-liberty-crd.yaml
+++ b/internal/deploy/kustomize/daily/base/websphere-liberty-crd.yaml
@@ -1540,7 +1540,7 @@ spec:
                     - IBM WebSphere Application Server Network Deployment
                     type: string
                   metric:
-                    description: 'Charge metric code. Defaults to Virtual Processor Core (VPC). Other option: Processor Value Unit (PVU)'
+                    description: Deprecated. Charge metric code is now automatically determined based on the specified product edition and entitlement source.
                     enum:
                     - Virtual Processor Core (VPC)
                     - Processor Value Unit (PVU)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -576,3 +576,12 @@ func Remove(list []string, s string) []string {
 	}
 	return list
 }
+
+func GetWLOLicenseAnnotations() map[string]string {
+	annotations := make(map[string]string)
+	annotations["productID"] = "cb1747ecb831410f88006195f024183f"
+	annotations["productName"] = "WebSphere Liberty Operator"
+	annotations["productMetric"] = "FREE"
+	annotations["productChargedContainers"] = "ALL"
+	return annotations
+}


### PR DESCRIPTION
- Add license annotations to Semeru compiler. Use WLO annotations as there are no annotations for Semeru
- Change default resources req of semeru compiler
- Change name of the Semeru container (from jitserver to semeru)
- Deprecate .spec.license.metric field