### PR TITLE
Update the semeru tests to run in onepipeline

### DIFF
--- a/bundle/tests/scorecard/kuttl/semeru/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/semeru/00-assert.yaml
@@ -32,14 +32,7 @@ spec:
       serviceAccountName: my-wsliberty-app
       schedulerName: default-scheduler
       containers:
-        - resources:
-            limits:
-              cpu: '8'
-              memory: 1200Mi
-            requests:
-              cpu: '1'
-              memory: 1200Mi
-          readinessProbe:
+        - readinessProbe:
             tcpSocket:
               port: 38400
             initialDelaySeconds: 5
@@ -48,7 +41,7 @@ spec:
             successThreshold: 1
             failureThreshold: 3
           terminationMessagePath: /dev/termination-log
-          name: jitserver
+          name: compiler
           command:
             - jitserver
           livenessProbe:
@@ -89,7 +82,7 @@ spec:
       volumes:
         - name: certs
           secret:
-            secretName: my-wsliberty-app-semeru-compiler-1-tls-ocp
+            secretName: my-wsliberty-app-semeru-compiler-1-tls-cm
             defaultMode: 420
       dnsPolicy: ClusterFirst
   strategy:

--- a/bundle/tests/scorecard/kuttl/semeru/03-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/semeru/03-assert.yaml
@@ -26,14 +26,7 @@ spec:
       serviceAccountName: my-wsliberty-app
       schedulerName: default-scheduler
       containers:
-        - resources:
-            limits:
-              cpu: '8'
-              memory: 1200Mi
-            requests:
-              cpu: '1'
-              memory: 1200Mi
-          readinessProbe:
+        - readinessProbe:
             tcpSocket:
               port: 38400
             initialDelaySeconds: 5
@@ -42,7 +35,7 @@ spec:
             successThreshold: 1
             failureThreshold: 3
           terminationMessagePath: /dev/termination-log
-          name: jitserver
+          name: compiler
           command:
             - jitserver
           livenessProbe:
@@ -83,7 +76,7 @@ spec:
       volumes:
         - name: certs
           secret:
-            secretName: my-wsliberty-app-semeru-compiler-1-tls-ocp
+            secretName: my-wsliberty-app-semeru-compiler-1-tls-cm
             defaultMode: 420
       dnsPolicy: ClusterFirst
   strategy:

--- a/bundle/tests/scorecard/kuttl/semeru/04-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/semeru/04-assert.yaml
@@ -26,14 +26,7 @@ spec:
       serviceAccountName: my-wsliberty-app
       schedulerName: default-scheduler
       containers:
-        - resources:
-            limits:
-              cpu: '8'
-              memory: 1200Mi
-            requests:
-              cpu: '1'
-              memory: 1200Mi
-          readinessProbe:
+        - readinessProbe:
             tcpSocket:
               port: 38400
             initialDelaySeconds: 5
@@ -42,7 +35,7 @@ spec:
             successThreshold: 1
             failureThreshold: 3
           terminationMessagePath: /dev/termination-log
-          name: jitserver
+          name: compiler
           command:
             - jitserver
           livenessProbe:
@@ -83,7 +76,7 @@ spec:
       volumes:
         - name: certs
           secret:
-            secretName: my-wsliberty-app-semeru-compiler-1-tls-ocp
+            secretName: my-wsliberty-app-semeru-compiler-1-tls-cm
             defaultMode: 420
       dnsPolicy: ClusterFirst
   strategy:

--- a/bundle/tests/scorecard/kuttl/semeru/05-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/semeru/05-assert.yaml
@@ -26,14 +26,7 @@ spec:
       serviceAccountName: my-wsliberty-app
       schedulerName: default-scheduler
       containers:
-        - resources:
-            limits:
-              cpu: '8'
-              memory: 1200Mi
-            requests:
-              cpu: '1'
-              memory: 1200Mi
-          readinessProbe:
+        - readinessProbe:
             tcpSocket:
               port: 38400
             initialDelaySeconds: 5
@@ -42,7 +35,7 @@ spec:
             successThreshold: 1
             failureThreshold: 3
           terminationMessagePath: /dev/termination-log
-          name: jitserver
+          name: compiler
           command:
             - jitserver
           livenessProbe:
@@ -83,7 +76,7 @@ spec:
       volumes:
         - name: certs
           secret:
-            secretName: my-wsliberty-app-semeru-compiler-2-tls-ocp
+            secretName: my-wsliberty-app-semeru-compiler-2-tls-cm
             defaultMode: 420
       dnsPolicy: ClusterFirst
   strategy:


### PR DESCRIPTION
- Remove resources check as they are not set by the test and are dependant on the cluster
- Change the name to compiler as that was a late code change
- Changed the secret name as the automation uses an installed certificate manager and not OCPs in-built manager
Signed-off-by: Jason Yong <jason_yong@uk.ibm.com>