### PR TITLE
update semeru tests to check correct resource limits

### DIFF
--- a/bundle/tests/scorecard/kuttl/semeru/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/semeru/00-assert.yaml
@@ -32,7 +32,14 @@ spec:
       serviceAccountName: my-wsliberty-app
       schedulerName: default-scheduler
       containers:
-        - readinessProbe:
+        - resources:
+            limits:
+              cpu: '2'
+              memory: 1200Mi
+            requests:
+              cpu: 100m
+              memory: 800Mi 
+          readinessProbe:
             tcpSocket:
               port: 38400
             initialDelaySeconds: 5

--- a/bundle/tests/scorecard/kuttl/semeru/03-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/semeru/03-assert.yaml
@@ -26,7 +26,14 @@ spec:
       serviceAccountName: my-wsliberty-app
       schedulerName: default-scheduler
       containers:
-        - readinessProbe:
+        - resources:
+            limits:
+              cpu: '2'
+              memory: 1200Mi
+            requests:
+              cpu: 100m
+              memory: 800Mi      
+          readinessProbe:
             tcpSocket:
               port: 38400
             initialDelaySeconds: 5

--- a/bundle/tests/scorecard/kuttl/semeru/04-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/semeru/04-assert.yaml
@@ -26,7 +26,14 @@ spec:
       serviceAccountName: my-wsliberty-app
       schedulerName: default-scheduler
       containers:
-        - readinessProbe:
+        - resources:
+            limits:
+              cpu: '2'
+              memory: 1200Mi
+            requests:
+              cpu: 100m
+              memory: 800Mi 
+          readinessProbe:
             tcpSocket:
               port: 38400
             initialDelaySeconds: 5

--- a/bundle/tests/scorecard/kuttl/semeru/05-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/semeru/05-assert.yaml
@@ -26,7 +26,14 @@ spec:
       serviceAccountName: my-wsliberty-app
       schedulerName: default-scheduler
       containers:
-        - readinessProbe:
+        - resources:
+            limits:
+              cpu: '2'
+              memory: 1200Mi
+            requests:
+              cpu: 100m
+              memory: 800Mi    
+          readinessProbe:
             tcpSocket:
               port: 38400
             initialDelaySeconds: 5

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -112,6 +112,7 @@ main() {
      install_rook
      install_serverless
      setup_knative_serving
+     install_cert_manager
      add_affinity_label_to_node
      create_image_content_source_policy
   elif [[ "$COMMAND" == "scorecard" ]]; then
@@ -323,8 +324,8 @@ install_rook() {
     tmp_dir=$(mktemp -d -t ceph-XXXXXXXXXX)
     cd "$tmp_dir"
 
-    git clone --single-branch -b v1.5.11 https://github.com/rook/rook.git
-    cd rook/cluster/examples/kubernetes/ceph
+    git clone --single-branch --branch master https://github.com/rook/rook.git
+    cd rook/deploy/examples
 
     oc create -f crds.yaml
     oc create -f common.yaml
@@ -402,6 +403,16 @@ EOF
     echo
   else
     echo "Knative Serving instance is already created."
+  fi
+}
+
+install_cert_manager() {
+  if ! oc get deployments -n cert-manager 2>/dev/null | grep cert-manager >/dev/null; then
+    echo "Installing cert-manager..."
+    oc apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.8.0/cert-manager.yaml
+    echo
+  else
+    echo "cert-manager is already installed."
   fi
 }
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -31,6 +31,10 @@ set -Eeo pipefail
 
 readonly USAGE="Usage: dev.sh all | init | login| build | catalog | subscribe | deploy | e2e | scorecard [ -host <ocp registry hostname url> -version <operator verion to build> -image <image name> -bundle <bundle image> -catalog <catalog image> -name <operator name> -namespace <namespace> -tempdir <temp dir> ]"
 
+warn() {
+  echo -e "${yel}Warning:${end} $1"
+}
+
 main() {
 
   parse_args "$@"


### PR DESCRIPTION
* Updated the semeru test to check for the correct resource limits
* Updated the dev.sh script to install the latest rook ceph version, install the certification manager required by some of the tests and fix "warn" error.
Signed-off-by: Jason Yong <jason_yong@uk.ibm.com>