### PR TITLE
Update kuttl timeouts for onepipeline tests

### DIFF
--- a/bundle/tests/scorecard/kuttl/semeru/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/semeru/00-assert.yaml
@@ -5,7 +5,7 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 60
+timeout: 120
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/scripts/pipeline/fyre-e2e.sh
+++ b/scripts/pipeline/fyre-e2e.sh
@@ -165,7 +165,7 @@ main() {
     echo "****** ${CONTROLLER_MANAGER_NAME} deployment is ready..."
 
     echo "****** Starting scorecard tests..."
-    operator-sdk scorecard --verbose --kubeconfig  ${HOME}/.kube/config --selector=suite=kuttlsuite --namespace="${TEST_NAMESPACE}" --service-account="scorecard-kuttl" --wait-time 30m ./bundle || {
+    operator-sdk scorecard --verbose --kubeconfig  ${HOME}/.kube/config --selector=suite=kuttlsuite --namespace="${TEST_NAMESPACE}" --service-account="scorecard-kuttl" --wait-time 45m ./bundle || {
        echo "****** Scorecard tests failed..."
        exit 1
     }


### PR DESCRIPTION
* Update overall timeout due to increased number of tests
* Increase the timeout for the semeru test as it has to download a large image everytime when run in Onepipeline