### PR TITLE
Add NetworkPolicy tests for CNCF Kubernetes (non-OCP) 

### DIFF
--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy-multiple-apps/00-assert.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy-multiple-apps/00-assert.yaml
@@ -1,0 +1,43 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: network-policy-frontend-rc
+spec:
+  ingress:
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - port: 9080
+          protocol: TCP
+        - port: 9443
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      liberty.websphere.ibm.com/name: network-policy-frontend-rc
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: network-policy-backend-rc
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/part-of: network-policy-test
+      ports:
+        - port: 9080
+          protocol: TCP
+        - port: 9443
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      liberty.websphere.ibm.com/name: network-policy-backend-rc
+  policyTypes:
+    - Ingress

--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy-multiple-apps/00-multiple-network-policies.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy-multiple-apps/00-multiple-network-policies.yaml
@@ -1,0 +1,30 @@
+apiVersion: liberty.websphere.ibm.com/v1
+kind: WebSphereLibertyApplication
+metadata:
+  name: network-policy-frontend-rc
+spec:
+  license:
+    accept: true
+  applicationName: network-policy-test
+  applicationImage: k8s.gcr.io/pause:2.0
+  expose: true
+  service:
+    port: 9080
+    ports:
+      - port: 9443
+        protocol: TCP
+---
+apiVersion: liberty.websphere.ibm.com/v1
+kind: WebSphereLibertyApplication
+metadata:
+  name: network-policy-backend-rc
+spec:
+  license:
+    accept: true
+  applicationName: network-policy-test
+  applicationImage: k8s.gcr.io/pause:2.0
+  service:
+    port: 9080
+    ports:
+      - port: 9443
+        protocol: TCP

--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy/00-assert.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy/00-assert.yaml
@@ -1,0 +1,22 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: network-policy-rc
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/part-of: network-policy-rc
+      ports:
+        - port: 8080
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      liberty.websphere.ibm.com/name: network-policy-rc
+  policyTypes:
+    - Ingress

--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy/00-network-policy-enabled-default.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy/00-network-policy-enabled-default.yaml
@@ -1,0 +1,10 @@
+apiVersion: liberty.websphere.ibm.com/v1
+kind: WebSphereLibertyApplication
+metadata:
+  name: network-policy-rc
+spec:
+  license:
+    accept: true
+  applicationImage: k8s.gcr.io/pause:2.0
+  service:
+    port: 8080

--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy/01-assert.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy/01-assert.yaml
@@ -1,0 +1,22 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: network-policy-rc
+spec:
+  ingress:
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - port: 8080
+          protocol: TCP
+        - port: 9090
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      liberty.websphere.ibm.com/name: network-policy-rc
+  policyTypes:
+    - Ingress

--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy/01-exposed-network-policy.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy/01-exposed-network-policy.yaml
@@ -1,0 +1,14 @@
+apiVersion: liberty.websphere.ibm.com/v1
+kind: WebSphereLibertyApplication
+metadata:
+  name: network-policy-rc
+spec:
+  license:
+    accept: true
+  applicationImage: k8s.gcr.io/pause:2.0
+  expose: true
+  service:
+    port: 8080
+    ports:
+      - port: 9090
+        protocol: TCP

--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy/02-assert.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy/02-assert.yaml
@@ -1,0 +1,24 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: network-policy-rc
+spec:
+  ingress:
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - port: 8080
+          protocol: TCP
+        - port: 9090
+          protocol: TCP
+        - port: 9091
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      liberty.websphere.ibm.com/name: network-policy-rc
+  policyTypes:
+    - Ingress

--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy/02-grow-network-policy.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy/02-grow-network-policy.yaml
@@ -1,0 +1,16 @@
+apiVersion: liberty.websphere.ibm.com/v1
+kind: WebSphereLibertyApplication
+metadata:
+  name: network-policy-rc
+spec:
+  license:
+    accept: true
+  applicationImage: k8s.gcr.io/pause:2.0
+  expose: true
+  service:
+    port: 8080
+    ports:
+      - port: 9090
+        protocol: TCP
+      - port: 9091
+        protocol: TCP

--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy/03-assert.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy/03-assert.yaml
@@ -1,0 +1,20 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: network-policy-rc
+spec:
+  ingress:
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - port: 8080
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      liberty.websphere.ibm.com/name: network-policy-rc
+  policyTypes:
+    - Ingress

--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy/03-errors.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy/03-errors.yaml
@@ -1,0 +1,11 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: network-policy-rc
+spec:
+  ingress:
+    - ports:
+        - port: 9090
+          protocol: TCP
+        - port: 9091
+          protocol: TCP

--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy/03-shrink-network-policy.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy/03-shrink-network-policy.yaml
@@ -1,0 +1,12 @@
+apiVersion: liberty.websphere.ibm.com/v1
+kind: WebSphereLibertyApplication
+metadata:
+  name: network-policy-rc
+spec:
+  license:
+    accept: true
+  applicationImage: k8s.gcr.io/pause:2.0
+  expose: true
+  service:
+    port: 8080
+    ports: []

--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy/04-assert.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy/04-assert.yaml
@@ -1,0 +1,22 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: network-policy-rc
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/part-of: network-policy-rc
+      ports:
+        - port: 8081
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      liberty.websphere.ibm.com/name: network-policy-rc
+  policyTypes:
+    - Ingress

--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy/04-errors.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy/04-errors.yaml
@@ -1,0 +1,11 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: network-policy-rc
+spec:
+  ingress:
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - port: 8080
+          protocol: TCP

--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy/04-unexposed-network-policy.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy/04-unexposed-network-policy.yaml
@@ -7,7 +7,5 @@ spec:
     accept: true
   applicationImage: k8s.gcr.io/pause:2.0
   expose: false
-  securityContext:
-    runAsUser: 1001
   service:
     port: 8081

--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy/04-unexposed-network-policy.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy/04-unexposed-network-policy.yaml
@@ -1,0 +1,13 @@
+apiVersion: liberty.websphere.ibm.com/v1
+kind: WebSphereLibertyApplication
+metadata:
+  name: network-policy-rc
+spec:
+  license:
+    accept: true
+  applicationImage: k8s.gcr.io/pause:2.0
+  expose: false
+  securityContext:
+    runAsUser: 1001
+  service:
+    port: 8081

--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy/05-assert.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy/05-assert.yaml
@@ -1,0 +1,27 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: network-policy-rc
+spec:
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              namespace: test
+          podSelector:
+            matchLabels:
+              foo: bar
+      ports:
+        - port: 8080
+          protocol: TCP
+        - port: 9090
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      liberty.websphere.ibm.com/name: network-policy-rc
+  policyTypes:
+    - Ingress

--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy/05-custom-labels-network-policy.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy/05-custom-labels-network-policy.yaml
@@ -1,0 +1,19 @@
+apiVersion: liberty.websphere.ibm.com/v1
+kind: WebSphereLibertyApplication
+metadata:
+  name: network-policy-rc
+spec:
+  license:
+    accept: true
+  applicationImage: k8s.gcr.io/pause:2.0
+  expose: false
+  networkPolicy:
+    namespaceLabels:
+      namespace: test
+    fromLabels:
+      foo: bar
+  service:
+    port: 8080
+    ports:
+      - port: 9090
+        protocol: TCP

--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy/06-assert.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy/06-assert.yaml
@@ -1,0 +1,24 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: network-policy-rc
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              foo: bar
+      ports:
+        - port: 8080
+          protocol: TCP
+        - port: 9090
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      liberty.websphere.ibm.com/name: network-policy-rc
+  policyTypes:
+    - Ingress

--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy/06-errors.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy/06-errors.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: network-policy-rc
+spec:
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              namespace: test

--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy/06-undef-network-labels-network-policy.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy/06-undef-network-labels-network-policy.yaml
@@ -1,0 +1,18 @@
+apiVersion: liberty.websphere.ibm.com/v1
+kind: WebSphereLibertyApplication
+metadata:
+  name: network-policy-rc
+spec:
+  license:
+    accept: true
+  applicationImage: k8s.gcr.io/pause:2.0
+  expose: false
+  networkPolicy:
+    namespaceLabels:
+    fromLabels:
+      foo: bar
+  service:
+    port: 8080
+    ports:
+      - port: 9090
+        protocol: TCP

--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy/07-assert.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy/07-assert.yaml
@@ -1,0 +1,24 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: network-policy-rc
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/part-of: network-policy-rc
+      ports:
+        - port: 8080
+          protocol: TCP
+        - port: 9090
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      liberty.websphere.ibm.com/name: network-policy-rc
+  policyTypes:
+    - Ingress

--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy/07-errors.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy/07-errors.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: network-policy-rc
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              foo: bar

--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy/07-undef-pod-labels-network-policy.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy/07-undef-pod-labels-network-policy.yaml
@@ -1,0 +1,16 @@
+apiVersion: liberty.websphere.ibm.com/v1
+kind: WebSphereLibertyApplication
+metadata:
+  name: network-policy-rc
+spec:
+  license:
+    accept: true
+  applicationImage: k8s.gcr.io/pause:2.0
+  expose: false
+  networkPolicy:
+    fromLabels:
+  service:
+    port: 8080
+    ports:
+      - port: 9090
+        protocol: TCP

--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy/08-assert.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy/08-assert.yaml
@@ -1,0 +1,22 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: network-policy-rc
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/part-of: network-policy-rc
+      ports:
+        - port: 8080
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      liberty.websphere.ibm.com/name: network-policy-rc
+  policyTypes:
+    - Ingress

--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy/08-undef-network-policy.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy/08-undef-network-policy.yaml
@@ -1,0 +1,11 @@
+apiVersion: liberty.websphere.ibm.com/v1
+kind: WebSphereLibertyApplication
+metadata:
+  name: network-policy-rc
+spec:
+  license:
+    accept: true
+  applicationImage: k8s.gcr.io/pause:2.0
+  networkPolicy:
+  service:
+    ports: []

--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy/09-allow-all-pods-any-ns.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy/09-allow-all-pods-any-ns.yaml
@@ -1,0 +1,14 @@
+apiVersion: liberty.websphere.ibm.com/v1
+kind: WebSphereLibertyApplication
+metadata:
+  name: network-policy-rc
+spec:
+  license:
+    accept: true
+  applicationImage: k8s.gcr.io/pause:2.0
+  expose: false
+  networkPolicy:
+    namespaceLabels: {}
+    fromLabels: {}
+  service:
+    port: 8080

--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy/09-assert.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy/09-assert.yaml
@@ -1,0 +1,20 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: network-policy-rc
+spec:
+  ingress:
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - port: 8080
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      liberty.websphere.ibm.com/name: network-policy-rc
+  policyTypes:
+    - Ingress

--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy/10-allow-labeled-pods-all-ns.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy/10-allow-labeled-pods-all-ns.yaml
@@ -1,0 +1,15 @@
+apiVersion: liberty.websphere.ibm.com/v1
+kind: WebSphereLibertyApplication
+metadata:
+  name: network-policy-rc
+spec:
+  license:
+    accept: true
+  applicationImage: k8s.gcr.io/pause:2.0
+  expose: false
+  networkPolicy:
+    namespaceLabels: {}
+    fromLabels:
+      foo: bar
+  service:
+    port: 8080

--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy/10-assert.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy/10-assert.yaml
@@ -1,0 +1,23 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: network-policy-rc
+spec:
+  ingress:
+    - from:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              foo: bar
+      ports:
+        - port: 8080
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      liberty.websphere.ibm.com/name: network-policy-rc
+  policyTypes:
+    - Ingress

--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy/11-allow-any-pod-same-ns.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy/11-allow-any-pod-same-ns.yaml
@@ -1,0 +1,15 @@
+apiVersion: liberty.websphere.ibm.com/v1
+kind: WebSphereLibertyApplication
+metadata:
+  name: network-policy-rc
+spec:
+  license:
+    accept: true
+  applicationImage: k8s.gcr.io/pause:2.0
+  expose: false
+  networkPolicy:
+    namespaceLabels:
+      namespace: test
+    fromLabels: {}
+  service:
+    port: 8080

--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy/11-assert.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy/11-assert.yaml
@@ -1,0 +1,23 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: network-policy-rc
+spec:
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              namespace: test
+          podSelector: {}
+      ports:
+        - port: 8080
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      liberty.websphere.ibm.com/name: network-policy-rc
+  policyTypes:
+    - Ingress

--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy/11-errors.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy/11-errors.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: network-policy-rc
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/part-of: network-policy-rc

--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy/12-disable-network-policy.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy/12-disable-network-policy.yaml
@@ -1,0 +1,12 @@
+apiVersion: liberty.websphere.ibm.com/v1
+kind: WebSphereLibertyApplication
+metadata:
+  name: network-policy-rc
+spec:
+  license:
+    accept: true
+  applicationImage: k8s.gcr.io/pause:2.0
+  networkPolicy:
+    disable: true
+  service:
+    port: 8081

--- a/bundle/tests/scorecard/kind-kuttl/kind-network-policy/12-errors.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/kind-network-policy/12-errors.yaml
@@ -1,0 +1,4 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: network-policy-rc

--- a/scripts/e2e-kind.sh
+++ b/scripts/e2e-kind.sh
@@ -145,6 +145,8 @@ setup_test() {
     mv bundle/tests/scorecard/kind-kuttl/ingress bundle/tests/scorecard/kuttl/
     mv bundle/tests/scorecard/kind-kuttl/ingress-certificate bundle/tests/scorecard/kuttl/
     mv bundle/tests/scorecard/kind-kuttl/ingress-manage-tls bundle/tests/scorecard/kuttl/
+    mv bundle/tests/scorecard/kind-kuttl/kind-network-policy bundle/tests/scorecard/kuttl/
+    mv bundle/tests/scorecard/kind-kuttl/kind-network-policy-multiple-apps bundle/tests/scorecard/kuttl/
     
     ## Remove tests that do not apply for kind cluster
     mv bundle/tests/scorecard/kuttl/network-policy bundle/tests/scorecard/kind-kuttl/


### PR DESCRIPTION
Fixes #303 
- Add network policy tests for non-OCP environments
- Tests multiple apps scenario
- Update e2e scripts to support running the tests, add missing `ingress-manage-tls` folder `mv` to `e2e-kind.sh` 

Currently missing due to problem doing key comparison with empty map i.e `namespaceSelector: {}`
- https://github.com/application-stacks/runtime-component-operator/blob/main/bundle/tests/scorecard/kuttl/network-policy-multiple-apps/00-errors.yaml
- https://github.com/application-stacks/runtime-component-operator/blob/main/bundle/tests/scorecard/kuttl/network-policy/09-errors.yaml
