### PR TITLE
Set rook-ceph version

### DIFF
--- a/scripts/setup-kind-cluster.sh
+++ b/scripts/setup-kind-cluster.sh
@@ -183,7 +183,7 @@ spec:
 EOF
 
   rm -rf /root/rook
-  git clone --single-branch --branch master https://github.com/rook/rook.git
+  git clone --single-branch --branch v1.10.11 https://github.com/rook/rook.git
   cd /root/rook/deploy/examples
   kubectl apply -f crds.yaml -f common.yaml -f operator.yaml
 


### PR DESCRIPTION
There has been a recent change to rook-ceph's master branch and is making the kind-e2e fail. Set to the latest version that is not affected by the new change.