### PR TITLE
Remove Docker creds from containerize step

### DIFF
--- a/.one-pipeline.yaml
+++ b/.one-pipeline.yaml
@@ -205,8 +205,6 @@ containerize:
     export PIPELINE_REGISTRY=$(get_env pipeline-registry)
     export PIPELINE_PRODUCTION_IMAGE=$(get_env pipeline-production-image)
     export PIPELINE_OPERATOR_IMAGE=$(get_env pipeline-operator-image)
-    export DOCKER_USERNAME=$(get_env docker-username)
-    export DOCKER_PASSWORD=$(get_env docker-password)
     export REDHAT_USERNAME=$(get_env redhat-user-id)
     export REDHAT_PASSWORD=$(get_env redhat-password)
     export REDHAT_BASE_IMAGE=$(get_env redhat-base-image)
@@ -265,7 +263,7 @@ containerize:
         make bundle-pipeline
 
         # Build catalog image
-        echo "${DOCKER_PASSWORD}" | docker login "${PIPELINE_REGISTRY}" -u "${DOCKER_USERNAME}" --password-stdin
+        echo "${PIPELINE_PASSWORD}" | docker login "${PIPELINE_REGISTRY}" -u "${PIPELINE_USERNAME}" --password-stdin
         echo "${REDHAT_PASSWORD}" | docker login "${REDHAT_REGISTRY}" -u "${REDHAT_USERNAME}" --password-stdin
         make catalog-pipeline-build
         make catalog-pipeline-push
@@ -300,7 +298,7 @@ containerize:
         # Build catalog image
         echo "Connecting to docker..."
 
-        echo "${DOCKER_PASSWORD}" | docker login "${PIPELINE_REGISTRY}" -u "${DOCKER_USERNAME}" --password-stdin
+        echo "${PIPELINE_PASSWORD}" | docker login "${PIPELINE_REGISTRY}" -u "${PIPELINE_USERNAME}" --password-stdin
         echo "${ARTIFACTORY_TOKEN}" | docker login "${ARTIFACTORY_REPO_URL}" -u "${ARTIFACTORY_USERNAME}" --password-stdin
         echo "${REDHAT_PASSWORD}" | docker login "${REDHAT_REGISTRY}" -u "${REDHAT_USERNAME}" --password-stdin
 
@@ -314,7 +312,7 @@ containerize:
     # Save artifacts
     ## disabled the ppc64le and s380x save for now (see build stanza above).  Once these are built, we can move forward with this section.
     # declare -a tags=("${RELEASE_TARGET}" "${RELEASE_TARGET}-amd64" "${RELEASE_TARGET}-ppc64le" "${RELEASE_TARGET}-s390x")
-    echo "${DOCKER_PASSWORD}" | docker login "${PIPELINE_REGISTRY}" -u "${DOCKER_USERNAME}" --password-stdin
+    echo "${PIPELINE_PASSWORD}" | docker login "${PIPELINE_REGISTRY}" -u "${PIPELINE_USERNAME}" --password-stdin
     echo "**** Saving Artifacts ****"
     declare -a tags=("${RELEASE_TARGET}" "${RELEASE_TARGET}-amd64")
     for i in "${tags[@]}"

--- a/Makefile
+++ b/Makefile
@@ -342,7 +342,7 @@ build-artifactory-manifest: setup-manifest
 build-all-manifest: build-pipeline-manifest build-artifactory-manifest
 
 bundle-pipeline:
-	./scripts/bundle-release.sh -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}" --registry "${PIPELINE_REGISTRY}" --prod-image "${PIPELINE_PRODUCTION_IMAGE}" --image "${PIPELINE_REGISTRY}/${PIPELINE_OPERATOR_IMAGE}" --release "${RELEASE_TARGET}"
+	./scripts/bundle-release.sh -u "${PIPELINE_USERNAME}" -p "${PIPELINE_PASSWORD}" --registry "${PIPELINE_REGISTRY}" --prod-image "${PIPELINE_PRODUCTION_IMAGE}" --image "${PIPELINE_REGISTRY}/${PIPELINE_OPERATOR_IMAGE}" --release "${RELEASE_TARGET}"
 
 bundle-artifactory:
 	./scripts/bundle-release.sh -u "${ARTIFACTORY_USERNAME}" -p "${ARTIFACTORY_TOKEN}" --registry "${ARTIFACTORY_REPO_URL}" --prod-image "${PIPELINE_PRODUCTION_IMAGE}" --image "${ARTIFACTORY_REPO_URL}/${PIPELINE_OPERATOR_IMAGE}" --release "${RELEASE_TARGET}"


### PR DESCRIPTION
docker-username and docker-password values are being used to login to staging registry.
Replacing them to use ibmcloud-api-user  and ibmcloud-api-key-staging values.