### PR TITLE
Support when arch="X"

### DIFF
--- a/.one-pipeline.yaml
+++ b/.one-pipeline.yaml
@@ -178,7 +178,6 @@ containerize:
 
     git clone https://$(get_env git-token)@github.ibm.com/websphere/operators.git
     cp -rf operators/scripts/build ./scripts/
-    
 
     echo "skopeo version"
     skopeo --version || exit 1
@@ -199,7 +198,6 @@ containerize:
       export PATH=$PATH:/usr/local/go/bin
       yum -y -q update
 
-      #  Build images
       export RELEASE_TARGET=$(get_env branch)
       
       if [[ -z $DISABLE_ARTIFACTORY ]]; then
@@ -211,6 +209,7 @@ containerize:
 
       # Docker login and setup build configurations
       scripts/build/build-initialize.sh
+
       # update Jenkins job to run shallow clone and scripts/build/build-initialize.sh
       if [[ "$arch" == "ZXP" ]]; then
         echo "<ciorchestrator> Sending request to build P and Z"
@@ -225,15 +224,15 @@ containerize:
         echo "<ciorchestrator> waiting on request to build P and Z"
         ./scripts/pipeline/await-ciorchestrator.sh --user "$W3_USERNAME" --password "$W3_PASSWORD" --pipelineId "$pipelineid"
       fi
-      # Build operator manifest (after 3 arch operator builds)
+
+      # Build operator manifest
       make build-manifest-pipeline REGISTRY=${PIPELINE_REGISTRY} IMAGE=${PIPELINE_OPERATOR_IMAGE}
 
       # Build bundle image
       make build-bundle-pipeline REGISTRY=${PIPELINE_REGISTRY}
 
-      # Build catalog image for amd64 first - then p and z
-      make build-catalog-pipeline REGISTRY=${PIPELINE_REGISTRY}
       # Build catalog image
+      make build-catalog-pipeline REGISTRY=${PIPELINE_REGISTRY}
       if [[ "$arch" == "ZXP" ]]; then
         echo "<ciorchestrator> Sending request to build P and Z catalogs"
         DISABLE_ARTIFACTORY=true ./scripts/pipeline/request-ciorchestrator.sh --command "make build-catalog-pipeline REGISTRY=${PIPELINE_REGISTRY}" --user "$W3_USERNAME" --password "$W3_PASSWORD" --branch "$RELEASE_TARGET" --repository "websphere-liberty-operator" --org "WASdev" --trigger "wlodocker" --configFile ".ci-orchestrator/websphere-liberty-operator-build.yml" 
@@ -244,7 +243,6 @@ containerize:
 
       # Build catalog manifest
       make build-manifest-pipeline REGISTRY=${PIPELINE_REGISTRY} IMAGE=${PIPELINE_OPERATOR_IMAGE}-catalog
-
 
       if [[ "$DISABLE_ARTIFACTORY" == "false" ]]; then
         echo "Running builds for artifactory repository."
@@ -259,6 +257,7 @@ containerize:
         
          # Docker login and setup build configurations
         scripts/build/build-initialize.sh
+
         # update Jenkins job to run shallow clone and scripts/build/build-initialize.sh
         if [[ "$arch" == "ZXP" ]]; then
           echo "<ciorchestrator> Sending request to build P and Z ( artifactory )"
@@ -273,15 +272,15 @@ containerize:
           echo "<ciorchestrator> waiting on request to build P and Z ( artifactory )"
           ./scripts/pipeline/await-ciorchestrator.sh --user "$W3_USERNAME" --password "$W3_PASSWORD" --pipelineId "$pipelineid"
         fi
-        # Build operator manifest (after 3 arch operator builds)
+
+        # Build operator manifest
         make build-manifest-pipeline REGISTRY=${ARTIFACTORY_REPO_URL} IMAGE=${PIPELINE_OPERATOR_IMAGE}
 
         # Build bundle image
         make build-bundle-pipeline REGISTRY=${ARTIFACTORY_REPO_URL}
 
-        # Build catalog image for amd64 first - then p and z
-        make build-catalog-pipeline REGISTRY=${ARTIFACTORY_REPO_URL}
         # Build catalog image
+        make build-catalog-pipeline REGISTRY=${ARTIFACTORY_REPO_URL}
         if [[ "$arch" == "ZXP" ]]; then
            echo "<ciorchestrator> Sending request to build P and Z catalogs ( artifactory )"
           ./scripts/pipeline/request-ciorchestrator.sh --command "make build-catalog-pipeline REGISTRY=${ARTIFACTORY_REPO_URL}" --user "$W3_USERNAME" --password "$W3_PASSWORD" --branch "$RELEASE_TARGET" --repository "websphere-liberty-operator" --org "WASdev" --trigger "wlodocker" --configFile ".ci-orchestrator/websphere-liberty-operator-build.yml" 
@@ -294,45 +293,53 @@ containerize:
         make build-manifest-pipeline REGISTRY=${ARTIFACTORY_REPO_URL} IMAGE=${PIPELINE_OPERATOR_IMAGE}-catalog
 
         echo "Completed pushing to artifactory."
-
       fi
     fi
 
     # Save artifacts
     ## disabled the ppc64le and s380x save for now (see build stanza above).  Once these are built, we can move forward with this section.
     echo "${PIPELINE_PASSWORD}" | docker login "${PIPELINE_REGISTRY}" -u "${PIPELINE_USERNAME}" --password-stdin
+
     echo "**** Saving Artifacts ****"
-    # declare -a tags=("${RELEASE_TARGET}" "${RELEASE_TARGET}-amd64")
-    declare -a tags=("${RELEASE_TARGET}" "${RELEASE_TARGET}-amd64" "${RELEASE_TARGET}-ppc64le" "${RELEASE_TARGET}-s390x")
+    if [[ "$arch" == "ZXP" ]]; then
+      declare -a tags=("${RELEASE_TARGET}" "${RELEASE_TARGET}-amd64" "${RELEASE_TARGET}-ppc64le" "${RELEASE_TARGET}-s390x")
+    else
+      declare -a tags=("${RELEASE_TARGET}" "${RELEASE_TARGET}-amd64")
+    fi
+
     for i in "${tags[@]}"
     do
       IMAGE=$PIPELINE_REGISTRY/$PIPELINE_OPERATOR_IMAGE:$i
       DIGEST="$(skopeo inspect docker://$IMAGE | grep Digest | grep -o 'sha[^\"]*')"
+      { ARCH="$(echo $i | grep -o '\(amd64\|s390x\|ppc64le\)$')" && TYPE="image"; } || { TYPE="manifest"; }
+
+      if [[ "$TYPE" == "manifest" ]]; then
+        echo "Saving artifact operator-$i type=$TYPE name=$IMAGE digest=$DIGEST"
+        save_artifact operator-$i type=$TYPE name="$IMAGE" "digest=$DIGEST"
+      else
+        echo "Saving artifact operator-$i type=$TYPE name=$IMAGE digest=$DIGEST arch=$ARCH"
+        save_artifact operator-$i type=$TYPE name="$IMAGE" "digest=$DIGEST" "arch=$ARCH"
+      fi
+    done
+
+    IMAGE=$PIPELINE_REGISTRY/$PIPELINE_OPERATOR_IMAGE-bundle:${RELEASE_TARGET}
+    DIGEST="$(skopeo inspect docker://$IMAGE | grep Digest | grep -o 'sha[^\"]*')"
+    echo "Saving artifact bundle-${RELEASE_TARGET} name=$IMAGE digest=$DIGEST"
+    save_artifact bundle-${RELEASE_TARGET} type=image name="$IMAGE" "digest=$DIGEST"
+
+    for i in "${tags[@]}"
+    do
+      IMAGE=$PIPELINE_REGISTRY/$PIPELINE_OPERATOR_IMAGE-catalog:$i
+      DIGEST="$(skopeo inspect docker://$IMAGE | grep Digest | grep -o 'sha[^\"]*')"
       { ARCH="$(echo $i | grep -o '\(amd64\|s390x\|ppc64le\)$')" && TYPE="image"; } || { ARCH="amd64" && TYPE="manifest"; }
-      echo "Saving artifact operator-$i name=$IMAGE digest=$DIGEST type=$TYPE"
-      save_artifact operator-$i type=$TYPE name="$IMAGE" "digest=$DIGEST" "arch=$ARCH" 
-    done
 
-    declare -a bundles=("${RELEASE_TARGET}")
-    for i in "${bundles[@]}"
-    do
-     IMAGE=$PIPELINE_REGISTRY/$PIPELINE_OPERATOR_IMAGE-bundle:$i
-     DIGEST="$(skopeo inspect docker://$IMAGE | grep Digest | grep -o 'sha[^\"]*')"
-     # ARCH=amd64
-     ARCH="$(echo $i | grep -o '\(amd64\|s390x\|ppc64le\)$' || echo 'amd64')"
-     echo "Saving artifact bundle-$i name=$IMAGE digest=$DIGEST"
-     save_artifact bundle-$i type=image name="$IMAGE" "digest=$DIGEST" "arch=$ARCH" 
-    done
-
-    declare -a catalogs=("${RELEASE_TARGET}")
-    for i in "${catalogs[@]}"
-    do
-     IMAGE=$PIPELINE_REGISTRY/$PIPELINE_OPERATOR_IMAGE-catalog:$i
-     DIGEST="$(skopeo inspect docker://$IMAGE | grep Digest | grep -o 'sha[^\"]*')"
-     # ARCH=amd64
-     ARCH="$(echo $i | grep -o '\(amd64\|s390x\|ppc64le\)$' || echo 'amd64')"
-     echo "Saving artifact catalog-$i name=$IMAGE digest=$DIGEST"
-     save_artifact catalog-$i type=image name="$IMAGE" "digest=$DIGEST" "arch=$ARCH" 
+      if [[ "$TYPE" == "manifest" ]]; then
+        echo "Saving artifact catalog-$i type=$TYPE name=$IMAGE digest=$DIGEST"
+        save_artifact catalog-$i type=$TYPE name="$IMAGE" "digest=$DIGEST"
+      else
+        echo "Saving artifact catalog-$i type=$TYPE name=$IMAGE digest=$DIGEST arch=$ARCH"
+        save_artifact catalog-$i type=$TYPE name="$IMAGE" "digest=$DIGEST" "arch=$ARCH"
+      fi
     done
 
     echo "MEND unified agent scan"


### PR DESCRIPTION
Currently build-manifest script creates manifest list with x, p and z images.
When arch is "X", p and z images are not built - so manifest creation will throw an error.
Edit the script so both modes are supported

Also edited saving artifacts portion to support arch=X, 