### PR TITLE
Add ownership labels to operator config map

### DIFF
--- a/controllers/webspherelibertyapplication_controller.go
+++ b/controllers/webspherelibertyapplication_controller.go
@@ -58,6 +58,16 @@ const (
 	OperatorName = "websphere-liberty-operator"
 )
 
+// Labels used for Operator resources (not for CRs)
+func GetOperatorLabels() map[string]string {
+	labels := map[string]string{
+		"app.kubernetes.io/instance":   OperatorName,
+		"app.kubernetes.io/name":       OperatorName,
+		"app.kubernetes.io/managed-by": "olm",
+	}
+	return labels
+}
+
 // ReconcileWebSphereLiberty reconciles a WebSphereLibertyApplication object
 type ReconcileWebSphereLiberty struct {
 	// This client, initialized using mgr.Client() above, is a split client

--- a/main.go
+++ b/main.go
@@ -141,7 +141,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	utils.CreateConfigMap(controllers.OperatorName)
+	utils.CreateConfigMap(controllers.OperatorName, controllers.GetOperatorLabels())
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {


### PR DESCRIPTION
This is do deal with issue #448 and is dependent on changes from application-stacks/runtime-component-operator#506