### PR TITLE
Update RCO module to include knative and operator configmap label updates

### DIFF
--- a/controllers/webspherelibertyapplication_controller.go
+++ b/controllers/webspherelibertyapplication_controller.go
@@ -47,7 +47,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -110,20 +109,9 @@ func (r *ReconcileWebSphereLiberty) Reconcile(ctx context.Context, request ctrl.
 	configMap, err := r.GetOpConfigMap(OperatorName, ns)
 	if err != nil {
 		reqLogger.Info("Failed to get websphere-liberty-operator config map, error: " + err.Error())
-		common.Config = common.DefaultOpConfig()
-		configMap = &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: OperatorName, Namespace: ns}}
-		configMap.Data = common.Config
+		oputils.CreateConfigMap(OperatorName)
 	} else {
 		common.Config.LoadFromConfigMap(configMap)
-	}
-
-	_, err = controllerutil.CreateOrUpdate(context.TODO(), r.GetClient(), configMap, func() error {
-		configMap.Data = common.Config
-		return nil
-	})
-
-	if err != nil {
-		reqLogger.Info("Failed to create or update websphere-liberty-operator config map, error: " + err.Error())
 	}
 
 	// Fetch the WebSphereLiberty instance
@@ -333,6 +321,7 @@ func (r *ReconcileWebSphereLiberty) Reconcile(ctx context.Context, request ctrl.
 			}
 		}
 		if isKnativeSupported {
+			reqLogger.Info("Knative is supported and Knative Service is enabled")
 			ksvc := &servingv1.Service{ObjectMeta: defaultMeta}
 			err = r.CreateOrUpdate(ksvc, instance, func() error {
 				oputils.CustomizeKnativeService(ksvc, instance)
@@ -345,6 +334,7 @@ func (r *ReconcileWebSphereLiberty) Reconcile(ctx context.Context, request ctrl.
 			}
 
 			instance.Status.Versions.Reconciled = lutils.OperandVersion
+			reqLogger.Info("Reconcile WebSphereLibertyApplication - completed")
 			return r.ManageSuccess(common.StatusConditionTypeReconciled, instance)
 		}
 		return r.ManageError(errors.New("failed to reconcile Knative service as operator could not find Knative CRDs"), common.StatusConditionTypeReconciled, instance)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/WASdev/websphere-liberty-operator
 go 1.19
 
 require (
-	github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20230413024947-1dca2a9877ad
+	github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20230421190839-08dca6236514
 	github.com/go-logr/logr v1.2.2
 	github.com/openshift/api v0.0.0-20220414050251-a83e6f8f1d50 // Openshift 4.9
 	github.com/openshift/library-go v0.0.0-20220630204433-c71d40c7de49

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210826220005-b48c857c3a0e/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
-github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20230413024947-1dca2a9877ad h1:LinEeZaTfyp80giRLqapwltcgCfFn6toj42Cl9NWe6I=
-github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20230413024947-1dca2a9877ad/go.mod h1:JsX0ioxZzA0yM1Sxg/1QKLg9dGqDXYvGZ+WwiQrMoxQ=
+github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20230421190839-08dca6236514 h1:ZSKbBVQH7C4PwfWzgG1s5m5tZA7N7MCR6ycyxoKfV+Q=
+github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20230421190839-08dca6236514/go.mod h1:JsX0ioxZzA0yM1Sxg/1QKLg9dGqDXYvGZ+WwiQrMoxQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=


### PR DESCRIPTION
- Set the security context on Knative Service (user specified or the default - the default matches what's set by Knative itself otherwise)
- Knative changed the label used to control visibility of route (adding the new label for now, we could remove the old label in the future if it's 100% not needed) - PR for https://github.com/application-stacks/runtime-component-operator/issues/515
- Always use utils method to create controller configmap (fix for https://github.com/application-stacks/runtime-component-operator/issues/506)