### PR TITLE
Replace default namespace to websphere-liberty for kustomize artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,8 +93,8 @@ endif
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:crdVersions=v1,generateEmbeddedObjectMeta=true"
 
-# Produce files under deploy/kustomize/daily with default namespace
-KUSTOMIZE_NAMESPACE = default
+# Produce files under deploy/kustomize/daily with websphere-liberty namespace
+KUSTOMIZE_NAMESPACE = websphere-liberty
 KUSTOMIZE_IMG = cp.stg.icr.io/cp/websphere-liberty-operator:main
 
 # Use docker if available. Otherwise default to podman. 

--- a/config/kustomize/operator/kustomization.yaml
+++ b/config/kustomize/operator/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
 - ../../manager
 
 # Adds namespace to all resources.
-namespace: default
+namespace: websphere-liberty
 namePrefix: websphere-liberty-
 
 # Labels to add to all resources and selectors.

--- a/config/kustomize/roles/kustomization.yaml
+++ b/config/kustomize/roles/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
 - ../../rbac
 
 # Adds namespace to all resources.
-namespace: default
+namespace: websphere-liberty
 namePrefix: websphere-liberty-
 
 # Labels to add to all resources and selectors.

--- a/deploy/releases/1.2.0/kustomize/base/kustomization.yaml
+++ b/deploy/releases/1.2.0/kustomize/base/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: default
+namespace: websphere-liberty
 
 resources:
   - websphere-liberty-crd.yaml

--- a/deploy/releases/1.2.0/kustomize/base/websphere-liberty-deployment.yaml
+++ b/deploy/releases/1.2.0/kustomize/base/websphere-liberty-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/name: websphere-liberty-operator
     control-plane: websphere-liberty-controller-manager
   name: websphere-liberty-controller-manager
-  namespace: default
+  namespace: websphere-liberty
 spec:
   replicas: 1
   selector:

--- a/deploy/releases/1.2.0/kustomize/base/websphere-liberty-roles.yaml
+++ b/deploy/releases/1.2.0/kustomize/base/websphere-liberty-roles.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: websphere-liberty-operator
     app.kubernetes.io/name: websphere-liberty-operator
   name: websphere-liberty-controller-manager
-  namespace: default
+  namespace: websphere-liberty
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/instance: websphere-liberty-operator
     app.kubernetes.io/name: websphere-liberty-operator
   name: websphere-liberty-leader-election-role
-  namespace: default
+  namespace: websphere-liberty
 rules:
 - apiGroups:
   - ""
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/instance: websphere-liberty-operator
     app.kubernetes.io/name: websphere-liberty-operator
   name: websphere-liberty-manager-role
-  namespace: default
+  namespace: websphere-liberty
 rules:
 - apiGroups:
   - apps
@@ -231,7 +231,7 @@ metadata:
     app.kubernetes.io/instance: websphere-liberty-operator
     app.kubernetes.io/name: websphere-liberty-operator
   name: websphere-liberty-leader-election-rolebinding
-  namespace: default
+  namespace: websphere-liberty
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -239,7 +239,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: websphere-liberty-controller-manager
-  namespace: default
+  namespace: websphere-liberty
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -248,7 +248,7 @@ metadata:
     app.kubernetes.io/instance: websphere-liberty-operator
     app.kubernetes.io/name: websphere-liberty-operator
   name: websphere-liberty-manager-rolebinding
-  namespace: default
+  namespace: websphere-liberty
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -256,4 +256,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: websphere-liberty-controller-manager
-  namespace: default
+  namespace: websphere-liberty

--- a/deploy/releases/1.2.0/kustomize/overlays/watch-all-namespaces/cluster-roles.yaml
+++ b/deploy/releases/1.2.0/kustomize/overlays/watch-all-namespaces/cluster-roles.yaml
@@ -12,7 +12,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: websphere-liberty-controller-manager
-  namespace: default
+  namespace: websphere-liberty
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -28,7 +28,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: websphere-liberty-controller-manager
-  namespace: default
+  namespace: websphere-liberty
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/deploy/releases/1.2.0/kustomize/overlays/watch-all-namespaces/kustomization.yaml
+++ b/deploy/releases/1.2.0/kustomize/overlays/watch-all-namespaces/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: default
+namespace: websphere-liberty
 
 bases:
 - ../../base

--- a/deploy/releases/1.2.0/kustomize/overlays/watch-all-namespaces/wlo-all-namespaces.yaml
+++ b/deploy/releases/1.2.0/kustomize/overlays/watch-all-namespaces/wlo-all-namespaces.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: websphere-liberty-controller-manager
+  namespace: websphere-liberty
 spec:
   template:
     spec:

--- a/deploy/releases/1.2.0/kustomize/overlays/watch-another-namespace/wlo-ns/wlo-deployment.yaml
+++ b/deploy/releases/1.2.0/kustomize/overlays/watch-another-namespace/wlo-ns/wlo-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: websphere-liberty-controller-manager
-  namespace: default
+  namespace: websphere-liberty
 spec:
   template:
     spec:

--- a/deploy/releases/1.2.0/kustomize/overlays/watch-another-namespace/wlo-ns/wlo-roles.yaml
+++ b/deploy/releases/1.2.0/kustomize/overlays/watch-another-namespace/wlo-ns/wlo-roles.yaml
@@ -2,30 +2,30 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: websphere-liberty-leader-election-role
-  namespace: default
+  namespace: websphere-liberty
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: websphere-liberty-manager-role
-  namespace: default
+  namespace: websphere-liberty
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: websphere-liberty-leader-election-rolebinding
-  namespace: default
+  namespace: websphere-liberty
 subjects:
 - kind: ServiceAccount
   name: websphere-liberty-controller-manager
-  namespace: default
+  namespace: websphere-liberty
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: websphere-liberty-manager-rolebinding
-  namespace: default
+  namespace: websphere-liberty
 subjects:
 - kind: ServiceAccount
   name: websphere-liberty-controller-manager
-  namespace: default
+  namespace: websphere-liberty

--- a/deploy/releases/1.2.0/kustomize/overlays/watch-another-namespace/wlo-ns/wlo-sa.yaml
+++ b/deploy/releases/1.2.0/kustomize/overlays/watch-another-namespace/wlo-ns/wlo-sa.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: websphere-liberty-controller-manager
-  namespace: default
+  namespace: websphere-liberty

--- a/internal/deploy/kustomize/daily/base/kustomization.yaml
+++ b/internal/deploy/kustomize/daily/base/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: default
+namespace: websphere-liberty
 
 resources:
   - websphere-liberty-crd.yaml

--- a/internal/deploy/kustomize/daily/base/websphere-liberty-deployment.yaml
+++ b/internal/deploy/kustomize/daily/base/websphere-liberty-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/name: websphere-liberty-operator
     control-plane: websphere-liberty-controller-manager
   name: websphere-liberty-controller-manager
-  namespace: default
+  namespace: websphere-liberty
 spec:
   replicas: 1
   selector:

--- a/internal/deploy/kustomize/daily/base/websphere-liberty-roles.yaml
+++ b/internal/deploy/kustomize/daily/base/websphere-liberty-roles.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: websphere-liberty-operator
     app.kubernetes.io/name: websphere-liberty-operator
   name: websphere-liberty-controller-manager
-  namespace: default
+  namespace: websphere-liberty
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/instance: websphere-liberty-operator
     app.kubernetes.io/name: websphere-liberty-operator
   name: websphere-liberty-leader-election-role
-  namespace: default
+  namespace: websphere-liberty
 rules:
 - apiGroups:
   - ""
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/instance: websphere-liberty-operator
     app.kubernetes.io/name: websphere-liberty-operator
   name: websphere-liberty-manager-role
-  namespace: default
+  namespace: websphere-liberty
 rules:
 - apiGroups:
   - apps
@@ -231,7 +231,7 @@ metadata:
     app.kubernetes.io/instance: websphere-liberty-operator
     app.kubernetes.io/name: websphere-liberty-operator
   name: websphere-liberty-leader-election-rolebinding
-  namespace: default
+  namespace: websphere-liberty
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -239,7 +239,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: websphere-liberty-controller-manager
-  namespace: default
+  namespace: websphere-liberty
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -248,7 +248,7 @@ metadata:
     app.kubernetes.io/instance: websphere-liberty-operator
     app.kubernetes.io/name: websphere-liberty-operator
   name: websphere-liberty-manager-rolebinding
-  namespace: default
+  namespace: websphere-liberty
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -256,4 +256,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: websphere-liberty-controller-manager
-  namespace: default
+  namespace: websphere-liberty

--- a/internal/deploy/kustomize/daily/overlays/watch-all-namespaces/cluster-roles.yaml
+++ b/internal/deploy/kustomize/daily/overlays/watch-all-namespaces/cluster-roles.yaml
@@ -12,7 +12,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: websphere-liberty-controller-manager
-  namespace: default
+  namespace: websphere-liberty
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -28,7 +28,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: websphere-liberty-controller-manager
-  namespace: default
+  namespace: websphere-liberty
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/internal/deploy/kustomize/daily/overlays/watch-all-namespaces/kustomization.yaml
+++ b/internal/deploy/kustomize/daily/overlays/watch-all-namespaces/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: default
+namespace: websphere-liberty
 
 bases:
 - ../../base

--- a/internal/deploy/kustomize/daily/overlays/watch-another-namespace/wlo-ns/wlo-deployment.yaml
+++ b/internal/deploy/kustomize/daily/overlays/watch-another-namespace/wlo-ns/wlo-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: websphere-liberty-controller-manager
-  namespace: default
+  namespace: websphere-liberty
 spec:
   template:
     spec:

--- a/internal/deploy/kustomize/daily/overlays/watch-another-namespace/wlo-ns/wlo-roles.yaml
+++ b/internal/deploy/kustomize/daily/overlays/watch-another-namespace/wlo-ns/wlo-roles.yaml
@@ -2,30 +2,30 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: websphere-liberty-leader-election-role
-  namespace: default
+  namespace: websphere-liberty
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: websphere-liberty-manager-role
-  namespace: default
+  namespace: websphere-liberty
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: websphere-liberty-leader-election-rolebinding
-  namespace: default
+  namespace: websphere-liberty
 subjects:
 - kind: ServiceAccount
   name: websphere-liberty-controller-manager
-  namespace: default
+  namespace: websphere-liberty
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: websphere-liberty-manager-rolebinding
-  namespace: default
+  namespace: websphere-liberty
 subjects:
 - kind: ServiceAccount
   name: websphere-liberty-controller-manager
-  namespace: default
+  namespace: websphere-liberty

--- a/internal/deploy/kustomize/daily/overlays/watch-another-namespace/wlo-ns/wlo-sa.yaml
+++ b/internal/deploy/kustomize/daily/overlays/watch-another-namespace/wlo-ns/wlo-sa.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: websphere-liberty-controller-manager
-  namespace: default
+  namespace: websphere-liberty


### PR DESCRIPTION
Issue: https://github.com/WASdev/websphere-liberty-operator/issues/461

Ran kuttl tests against all install modes:
`kubectl apply -k base`
`kubectl apply -k examples/watch-own-namespace`
`kubectl apply -k overlays/watch-another-namespace`
`kubectl apply -k examples/watch-another-namespace`
`kubectl apply -k examples/watch-all-namespaces`
`kubectl apply -k examples/watch-all-namespaces`

- All tests passed
- Updated pause image to sample app image now that multi-arch is supported