### PR TITLE
Add getting started image back to the tests

### DIFF
--- a/bundle/tests/scorecard/kuttl/license/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/license/00-assert.yaml
@@ -11,7 +11,7 @@ apiVersion: v1
 kind: Pod
 spec:
   containers:
-  - image: icr.io/appcafe/websphere-liberty:full-java8-openj9-ubi
+  - image: icr.io/appcafe/open-liberty/samples/getting-started
 status:
   containerStatuses:
   - ready: true

--- a/bundle/tests/scorecard/kuttl/license/00-default.yaml
+++ b/bundle/tests/scorecard/kuttl/license/00-default.yaml
@@ -8,6 +8,6 @@ metadata:
 spec:
   license:
     accept: true
-  applicationImage: icr.io/appcafe/websphere-liberty:full-java8-openj9-ubi
+  applicationImage: icr.io/appcafe/open-liberty/samples/getting-started
   replicas: 1
 

--- a/bundle/tests/scorecard/kuttl/license/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/license/01-assert.yaml
@@ -11,7 +11,7 @@ apiVersion: v1
 kind: Pod
 spec:
   containers:
-  - image: icr.io/appcafe/websphere-liberty:full-java8-openj9-ubi
+  - image: icr.io/appcafe/open-liberty/samples/getting-started
 status:
   containerStatuses:
   - ready: true

--- a/bundle/tests/scorecard/kuttl/license/01-core.yaml
+++ b/bundle/tests/scorecard/kuttl/license/01-core.yaml
@@ -9,6 +9,6 @@ spec:
     accept: true
     edition: IBM WebSphere Application Server Liberty Core
     productEntitlementSource: IBM WebSphere Application Server Family Edition
-  applicationImage: icr.io/appcafe/websphere-liberty:full-java8-openj9-ubi
+  applicationImage: icr.io/appcafe/open-liberty/samples/getting-started
   replicas: 1
 

--- a/bundle/tests/scorecard/kuttl/license/02-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/license/02-assert.yaml
@@ -11,7 +11,7 @@ apiVersion: v1
 kind: Pod
 spec:
   containers:
-  - image: icr.io/appcafe/websphere-liberty:full-java8-openj9-ubi
+  - image: icr.io/appcafe/open-liberty/samples/getting-started
 status:
   containerStatuses:
   - ready: true

--- a/bundle/tests/scorecard/kuttl/license/02-nd.yaml
+++ b/bundle/tests/scorecard/kuttl/license/02-nd.yaml
@@ -9,6 +9,6 @@ spec:
     accept: true
     edition: IBM WebSphere Application Server Network Deployment
     productEntitlementSource: IBM Cloud Pak for Applications
-  applicationImage: icr.io/appcafe/websphere-liberty:full-java8-openj9-ubi
+  applicationImage: icr.io/appcafe/open-liberty/samples/getting-started
   replicas: 1
 

--- a/bundle/tests/scorecard/kuttl/probe/00-liberty-probe.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/00-liberty-probe.yaml
@@ -4,9 +4,8 @@ metadata:
   name: probes-wsliberty
 spec:
   license:
-    accept: true
-# Replacing icr.io/appcafe/open-liberty/samples/getting-started until it has a ppc64l and s390x image     
-  applicationImage: icr.io/appcafe/websphere-liberty:full-java8-openj9-ubi
+    accept: true     
+  applicationImage: icr.io/appcafe/open-liberty/samples/getting-started
   replicas: 1
   expose: false
   probes:

--- a/bundle/tests/scorecard/kuttl/probe/03-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/03-assert.yaml
@@ -43,8 +43,6 @@ spec:
             successThreshold: 1
             failureThreshold: 20
 status:
-# not checking readyReplicas or replicas while replacing icr.io/appcafe/open-liberty/samples/getting-started 
-# icr.io/appcafe/websphere-liberty:full-java8-openj9-ubi uses different default ports
-# readyReplicas: 1
-# replicas: 1
+  readyReplicas: 1
+  replicas: 1
   updatedReplicas: 1

--- a/bundle/tests/scorecard/kuttl/probe/03-liberty-probe-defaults.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/03-liberty-probe-defaults.yaml
@@ -5,8 +5,7 @@ metadata:
 spec:
   license:
     accept: true
-# Replacing icr.io/appcafe/open-liberty/samples/getting-started until it has a ppc64l and s390x image
-  applicationImage: icr.io/appcafe/websphere-liberty:full-java8-openj9-ubi
+  applicationImage: icr.io/appcafe/open-liberty/samples/getting-started
   manageTLS: false
   service:
     port: 9443

--- a/bundle/tests/scorecard/kuttl/probe/04-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/04-assert.yaml
@@ -43,8 +43,6 @@ spec:
             successThreshold: 1
             failureThreshold: 5
 status:
-# not checking readyReplicas or replicas while replacing icr.io/appcafe/open-liberty/samples/getting-started 
-# with icr.io/appcafe/websphere-liberty:full-java8-openj9-ubi 
-# readyReplicas: 1
-# replicas: 1
+  readyReplicas: 1
+  replicas: 1
   updatedReplicas: 1

--- a/bundle/tests/scorecard/kuttl/probe/04-liberty-probe-override.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/04-liberty-probe-override.yaml
@@ -5,8 +5,7 @@ metadata:
 spec:
   license:
     accept: true
-# Replacing icr.io/appcafe/open-liberty/samples/getting-started until it has a ppc64l and s390x image
-  applicationImage: icr.io/appcafe/websphere-liberty:full-java8-openj9-ubi
+  applicationImage: icr.io/appcafe/open-liberty/samples/getting-started
   service:
     port: 9443
   replicas: 1

--- a/bundle/tests/scorecard/kuttl/probe/05-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/05-assert.yaml
@@ -23,8 +23,6 @@ spec:
             successThreshold: 1
             failureThreshold: 20
 status:
-# not checking readyReplicas or replicas while replacing icr.io/appcafe/open-liberty/samples/getting-started 
-# icr.io/appcafe/websphere-liberty:full-java8-openj9-ubi uses different default ports
-#  readyReplicas: 1
-#  replicas: 1
+  readyReplicas: 1
+  replicas: 1
   updatedReplicas: 1

--- a/bundle/tests/scorecard/kuttl/probe/05-liberty-probe-undef.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/05-liberty-probe-undef.yaml
@@ -4,9 +4,8 @@ metadata:
   name: probes-wsliberty
 spec:
   license:
-    accept: true
-# Replacing icr.io/appcafe/open-liberty/samples/getting-started until it has a ppc64l and s390x image    
-  applicationImage: icr.io/appcafe/websphere-liberty:full-java8-openj9-ubi
+    accept: true   
+  applicationImage: icr.io/appcafe/open-liberty/samples/getting-started
   service:
     port: 9443
   probes:


### PR DESCRIPTION
Reverted changes make to kuttl e2e tests now that the getting started app is multiarch