### PR TITLE
Update skopeo command in .one-pipeline-cd.yaml

### DIFF
--- a/.one-pipeline-cd.yaml
+++ b/.one-pipeline-cd.yaml
@@ -23,7 +23,7 @@ setup:
       echo "${DIGEST}"
       echo "${APP}" | jq '.'
 
-      SAVED_DIGEST="$(skopeo inspect docker://$ARTIFACT | grep Digest | grep -o 'sha[^\"]*')"
+      SAVED_DIGEST="$(skopeo inspect docker://$ARTIFACT | jq '.Digest'| sed -e 's/"//g')"
       if [[ ${DIGEST} == ${SAVED_DIGEST} ]]; then
         echo "Image, $ARTIFACT, passes validation"
       else


### PR DESCRIPTION
Replace ` | grep Digest | grep -o 'sha[^\"]*' ` in the skopeo command in .onepipeline-cd.yaml with `| jq '.Digest'| sed -e 's/"//g'` to ensure only the digest is returned