### PR TITLE
Enable a tests only build in onepipeline

### DIFF
--- a/.one-pipeline.yaml
+++ b/.one-pipeline.yaml
@@ -119,6 +119,14 @@ static-scan:
       exit 0
     fi
 
+    SKIP_SCANS=$(get_env SKIP_SCANS)
+    SKIP_SCANS="$(echo "$SKIP_SCANS" | tr '[:upper:]' '[:lower:]')"
+
+    if [[ ! -z "$SKIP_SCANS" && "$SKIP_SCANS" != "false" && "$SKIP_SCANS" != "no"  ]]; then
+      echo "Skipping static-scan. This is a test run only"
+      exit 0
+    fi
+
     BRANCH=$(get_env branch) 
     read -r SONAR_HOST_URL <<< "$(get_env sonarqube | jq -r '.parameters.dashboard_url' | sed 's:/*$::')"
     read -r SONAR_USER <<< "$(get_env sonarqube | jq -r '.parameters.user_login')"
@@ -140,6 +148,50 @@ static-scan:
     #echo "$SONAR_PASS" >> /tmp/sonarqube-token
     "${COMMONS_PATH}"/static-scan/run.sh
 
+compliance-checks:
+  image: icr.io/continuous-delivery/pipeline/pipeline-base-ubi:3.3
+  dind: true
+  abort_on_failure: false
+  image_pull_policy: IfNotPresent  
+  sources:
+  - repo: https://github.ibm.com/open-toolchain/compliance-commons.git
+    sha: 38149a3644798c0b5679e6d8cdf999ce7f6e5142
+    path: cra
+  - repo: https://github.ibm.com/open-toolchain/compliance-commons.git
+    sha: 56cb780f891167b93b95d6f477ad7dce79f3df16
+    path: doi
+  - repo: https://github.ibm.com/open-toolchain/compliance-commons.git
+    sha: 7815b2273f9721d6edbdaf9bddb18e44d070b238
+    path: detect-secrets
+  - repo: https://github.ibm.com/open-toolchain/compliance-commons.git
+    sha: 38149a3644798c0b5679e6d8cdf999ce7f6e5142
+    path: compliance-checks
+  - repo: https://github.ibm.com/open-toolchain/compliance-commons.git
+    sha: 3e927695cfdb4f1bb8b25697ae67a10983de9a8c
+    path: mend  
+  
+  script: |
+    #!/usr/bin/env bash
+    
+    echo $STAGE
+    
+    PERIODIC_SCAN=$(get_env periodic-rescan)
+    PERIODIC_SCAN="$(echo "$PERIODIC_SCAN" | tr '[:upper:]' '[:lower:]')"
+
+    if [[ ! -z "$PERIODIC_SCAN" && "$PERIODIC_SCAN" != "false" && "$PERIODIC_SCAN" != "no"  ]]; then
+      echo "Skipping static-scan. This is a periodic run that is only meant to produce CVE information."
+      exit 0
+    fi
+
+    SKIP_SCANS=$(get_env SKIP_SCANS)
+    SKIP_SCANS="$(echo "$SKIP_SCANS" | tr '[:upper:]' '[:lower:]')"
+
+    if [[ ! -z "$SKIP_SCANS" && "$SKIP_SCANS" != "false" && "$SKIP_SCANS" != "no"  ]]; then
+      echo "Skipping static-scan. This is a test run only"
+      exit 0
+    fi
+
+    "${COMMONS_PATH}"/compliance-checks/run.sh
 
 containerize:
   dind: true
@@ -368,6 +420,14 @@ sign-artifact:
       exit 0
     fi
 
+    SKIP_SCANS=$(get_env SKIP_SCANS)
+    SKIP_SCANS="$(echo "$SKIP_SCANS" | tr '[:upper:]' '[:lower:]')"
+
+    if [[ ! -z "$SKIP_SCANS" && "$SKIP_SCANS" != "false" && "$SKIP_SCANS" != "no"  ]]; then
+      echo "Skipping static-scan. This is a test run only"
+      exit 0
+    fi
+
 deploy:
   image: icr.io/continuous-delivery/pipeline/pipeline-base-ubi:3.12
   script: |
@@ -403,6 +463,14 @@ dynamic-scan:
 
     if [[ ! -z "$PERIODIC_SCAN" && "$PERIODIC_SCAN" != "false" && "$PERIODIC_SCAN" != "no"  ]]; then
       echo "Skipping dynamic-scan. This is a periodic run that is only meant to produce CVE information."
+      exit 0
+    fi
+
+    SKIP_SCANS=$(get_env SKIP_SCANS)
+    SKIP_SCANS="$(echo "$SKIP_SCANS" | tr '[:upper:]' '[:lower:]')"
+
+    if [[ ! -z "$SKIP_SCANS" && "$SKIP_SCANS" != "false" && "$SKIP_SCANS" != "no"  ]]; then
+      echo "Skipping static-scan. This is a test run only"
       exit 0
     fi
 
@@ -463,6 +531,14 @@ scan-artifact:
 
     echo $STAGE
 
+    SKIP_SCANS=$(get_env SKIP_SCANS)
+    SKIP_SCANS="$(echo "$SKIP_SCANS" | tr '[:upper:]' '[:lower:]')"
+
+    if [[ ! -z "$SKIP_SCANS" && "$SKIP_SCANS" != "false" && "$SKIP_SCANS" != "no"  ]]; then
+      echo "Skipping static-scan. This is a test run only"
+      exit 0
+    fi
+
     # ========== Security Scanner ==========
     ./scripts/pipeline/ci_to_secure_pipeline_scan.sh
 
@@ -479,6 +555,14 @@ release:
 
     if [[ ! -z "$PERIODIC_SCAN" && "$PERIODIC_SCAN" != "false" && "$PERIODIC_SCAN" != "no"  ]]; then
       echo "Skipping release. This is a periodic run that is only meant to produce CVE information."
+      exit 0
+    fi
+    
+    SKIP_SCANS=$(get_env SKIP_SCANS)
+    SKIP_SCANS="$(echo "$SKIP_SCANS" | tr '[:upper:]' '[:lower:]')"
+
+    if [[ ! -z "$SKIP_SCANS" && "$SKIP_SCANS" != "false" && "$SKIP_SCANS" != "no"  ]]; then
+      echo "Skipping static-scan. This is a test run only"
       exit 0
     fi
 


### PR DESCRIPTION
Introduce a SKIP_SCANS environment variable to the onepipeline builds to reduce the time it takes to run a build if we are just looking at the test.