### PR TITLE
365: Add install mode testing of all modes in one pass

### DIFF
--- a/scripts/pipeline/ocp-cluster-e2e.sh
+++ b/scripts/pipeline/ocp-cluster-e2e.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-readonly usage="Usage: ocp-cluster-e2e.sh -u <docker-username> -p <docker-password> --cluster-url <url> --cluster-token <token> --registry-name <name> --registry-image <ns/image> --registry-user <user> --registry-password <password> --release <daily|release-tag> --test-tag <test-id> --catalog-image <catalog-image> --channel <channel>"
+readonly usage="Usage: ocp-cluster-e2e.sh -u <docker-username> -p <docker-password> --cluster-url <url> --cluster-token <token> --registry-name <name> --registry-image <ns/image> --registry-user <user> --registry-password <password> --release <daily|release-tag> --test-tag <test-id> --catalog-image <catalog-image> --channel <channel> --install-mode <install-mode>"
 readonly OC_CLIENT_VERSION="latest-4.10"
 readonly CONTROLLER_MANAGER_NAME="wlo-controller-manager"
 
@@ -22,17 +22,31 @@ setup_env() {
     echo "****** Logging into remote cluster..."
     oc login "${CLUSTER_URL}" -u "${CLUSTER_USER:-kubeadmin}" -p "${CLUSTER_TOKEN}" --insecure-skip-tls-verify=true
 
-    # Set variables for rest of script to use
+    # set TEST Namespace 
     readonly TEST_NAMESPACE="wlo-test-${TEST_TAG}"
-    if [[ $INSTALL_MODE = "SingleNamespace" ]]; then
-      readonly INSTALL_NAMESPACE="wlo-test-single-namespace-${TEST_TAG}"
-    elif [[ $INSTALL_MODE = "AllNamespaces" ]]; then
-      readonly INSTALL_NAMESPACE="openshift-operators"
+
+    # Set selected install mode
+    if [[ $INSTALL_MODE = "AllInstallModes" ]]; then
+      SELECTED_INSTALL_MODE="OwnNamespace"
     else
-      readonly INSTALL_NAMESPACE="wlo-test-${TEST_TAG}"
+      SELECTED_INSTALL_MODE=$INSTALL_MODE
+    fi
+}
+
+setup_namespaces() {
+    echo "******************************************************************************"
+    echo "********** Start of test for install mode: ${SELECTED_INSTALL_MODE}"
+    echo "******************************************************************************"
+
+    if [[ $SELECTED_INSTALL_MODE = "SingleNamespace" ]]; then
+      INSTALL_NAMESPACE="wlo-test-single-namespace-${TEST_TAG}"
+    elif [[ $SELECTED_INSTALL_MODE = "AllNamespaces" ]]; then
+      INSTALL_NAMESPACE="openshift-operators"
+    else
+      INSTALL_NAMESPACE="wlo-test-${TEST_TAG}"
     fi
 
-    if [ $INSTALL_MODE != "AllNamespaces" ]; then
+    if [ $SELECTED_INSTALL_MODE != "AllNamespaces" ]; then
       echo "****** Creating install namespace: ${INSTALL_NAMESPACE} for release ${RELEASE}"
       oc new-project "${INSTALL_NAMESPACE}" || oc project "${INSTALL_NAMESPACE}"
     fi
@@ -46,6 +60,8 @@ setup_env() {
 
 ## cleanup_env : Delete generated resources that are not bound to a test INSTALL_NAMESPACE.
 cleanup_env() {
+  echo "****** Entering cleanup_env()"
+
   ## Delete CRDs
   WLO_CRD_NAMES=$(oc get crd -o name | grep liberty.websphere | cut -d/ -f2)
   echo "*** Deleting CRDs ***"
@@ -64,15 +80,33 @@ cleanup_env() {
   echo "*** ${WLO_CSV_NAME}"
   oc -n $INSTALL_NAMESPACE delete csv $WLO_CSV_NAME
 
-  if [ $INSTALL_MODE != "OwnNamespace" ]; then
+  if [ $SELECTED_INSTALL_MODE != "OwnNamespace" ]; then
     echo "*** Deleting project ${TEST_NAMESPACE}"
     oc delete project "${TEST_NAMESPACE}"
+    delete_project_wait $TEST_NAMESPACE
   fi
 
-  if [ $INSTALL_MODE != "AllNamespaces" ]; then
+  if [ $SELECTED_INSTALL_MODE != "AllNamespaces" ]; then
     echo "*** Deleting project ${INSTALL_NAMESPACE}"
     oc delete project "${INSTALL_NAMESPACE}"
+    delete_project_wait $INSTALL_NAMESPACE
   fi
+}
+
+delete_project_wait() {
+    i=1
+    until [ $i -gt 31 ]
+    do
+      result=$(oc projects | grep -c $1)
+      if (( $result == 0 )); then
+        echo "*** Project ${1} has been deleted"
+        i=99
+      else
+        echo "*** Waiting for project ${1} to be deleted - pass ${i}"
+        sleep 10
+        ((i=i+1))
+      fi
+    done
 }
 
 ## trap_cleanup : Call cleanup_env and exit. For use by a trap to detect if the script is exited at any point.
@@ -174,6 +208,7 @@ main() {
 
     echo "****** Setting up test environment..."
     setup_env
+    setup_namespaces
 
     if [[ "${ARCHITECTURE}" != "X" ]]; then
         echo "****** Setting up tests for ${ARCHITECTURE} architecture"
@@ -218,8 +253,31 @@ main() {
           echo "rook-ceph up"
       fi
     fi
-    echo "****** Installing operator from catalog: ${CATALOG_IMAGE} using install mode of ${INSTALL_MODE}"
-    echo "****** Install namespace is ${INSTALL_NAMESPACE}.  Test namespace is ${TEST_NAMESPACE}"    
+
+    test_common
+    result=$?
+
+    if [[ $INSTALL_MODE = "AllInstallModes" ]]; then
+      # When all is selected, the default (initial) path is ownNamespace INSTALL_MODE.
+      # When that completes, we perform two more passes.  One for singleNamespace and one for allNamespaces  
+      SELECTED_INSTALL_MODE="SingleNamespace"
+      setup_namespaces
+      test_common
+      singleResult=$?
+
+      SELECTED_INSTALL_MODE="AllNamespaces"
+      setup_namespaces
+      test_common
+      allResult=$?
+
+      result=$(($result + $singleResult + $allResult))
+    fi
+
+    return $result
+}
+
+test_common() { 
+    echo "****** Entering test_common()"
     install_operator
 
     # Wait for operator deployment to be ready
@@ -229,6 +287,7 @@ main() {
     done
 
     echo "****** ${CONTROLLER_MANAGER_NAME} deployment is ready..."
+
     if [[ "$ARCHITECTURE" != "Z" ]]; then
     echo "****** Testing on ${ARCHITECTURE} so starting scorecard tests..."
     operator-sdk scorecard --verbose --kubeconfig  ${HOME}/.kube/config --selector=suite=kuttlsuite --namespace="${TEST_NAMESPACE}" --service-account="scorecard-kuttl" --wait-time 45m ./bundle || {
@@ -254,6 +313,10 @@ main() {
 }
 
 install_operator() {
+    echo "****** Entering install_operator()"
+    echo "****** Installing operator from catalog: ${CATALOG_IMAGE} using install mode of ${SELECTED_INSTALL_MODE}"
+    echo "****** Install namespace is ${INSTALL_NAMESPACE}.  Test namespace is ${TEST_NAMESPACE}"    
+
     # Apply the catalog
     echo "****** Applying the catalog source..."
     cat <<EOF | oc apply -f -
@@ -269,7 +332,7 @@ spec:
   publisher: IBM
 EOF
 
-if [ $INSTALL_MODE != "AllNamespaces" ]; then
+if [ $SELECTED_INSTALL_MODE != "AllNamespaces" ]; then
     echo "****** Applying the operator group..."
     cat <<EOF | oc apply -f -
 apiVersion: operators.coreos.com/v1


### PR DESCRIPTION
This is a continuation of the work done for issue 365 to support testing of install modes All Namespaces, Single Namespace and Own Namespace.  This PR contains changes needed to test all three modes in a single build.