### PR TITLE
Get monitoring test to work on kind

### DIFF
--- a/bundle/tests/scorecard/kuttl/monitor/02-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/monitor/02-assert.yaml
@@ -17,7 +17,7 @@ spec:
       app.kubernetes.io/instance: service-monitor-wsliberty
   endpoints:
   - path: "/path"
-    scheme: "myScheme"
+    scheme: "HTTPS"
     port: 9443-tcp
     params:
       params:

--- a/bundle/tests/scorecard/kuttl/monitor/02-update-monitor.yaml
+++ b/bundle/tests/scorecard/kuttl/monitor/02-update-monitor.yaml
@@ -6,7 +6,7 @@ spec:
   monitoring:
     endpoints:
     - path: "/path"
-      scheme: "myScheme"
+      scheme: "HTTPS"
       params:
         params:
         - "param1"


### PR DESCRIPTION
The clusters used for kind testing use a newer version of Prometheus which insist on the scheme name being either HTTPS or HTTP, so this test fails there.