### PR TITLE
472: Add ability to acceptance test release driver

### DIFF
--- a/.one-pipeline.yaml
+++ b/.one-pipeline.yaml
@@ -95,6 +95,14 @@ test:
       exit 0
     fi
 
+    RELEASE_ACCEPTANCE_TEST=$(get_env release-acceptance-test)
+    RELEASE_ACCEPTANCE_TEST="$(echo "$RELEASE_ACCEPTANCE_TEST" | tr '[:upper:]' '[:lower:]')"
+
+    if [[ ! -z "$RELEASE_ACCEPTANCE_TEST" && "$RELEASE_ACCEPTANCE_TEST" != "false" && "$RELEASE_ACCEPTANCE_TEST" != "no"  ]]; then
+      echo "Skipping unit-tests. This run is for a release acceptance test only."
+      exit 0
+    fi
+
     ## Setup required tooling
     make setup-go GO_RELEASE_VERSION=$(get_env go-version)
     export PATH=$PATH:/usr/local/go/bin
@@ -124,6 +132,14 @@ static-scan:
 
     if [[ ! -z "$SKIP_SCANS" && "$SKIP_SCANS" != "false" && "$SKIP_SCANS" != "no"  ]]; then
       echo "Skipping static-scan. This is a test run only"
+      exit 0
+    fi
+    
+    RELEASE_ACCEPTANCE_TEST=$(get_env release-acceptance-test)
+    RELEASE_ACCEPTANCE_TEST="$(echo "$RELEASE_ACCEPTANCE_TEST" | tr '[:upper:]' '[:lower:]')"
+
+    if [[ ! -z "$RELEASE_ACCEPTANCE_TEST" && "$RELEASE_ACCEPTANCE_TEST" != "false" && "$RELEASE_ACCEPTANCE_TEST" != "no"  ]]; then
+      echo "Skipping static-scan. This run is for a release acceptance test only."
       exit 0
     fi
 
@@ -210,6 +226,8 @@ containerize:
 
     PERIODIC_SCAN=$(get_env periodic-rescan)
     PERIODIC_SCAN="$(echo "$PERIODIC_SCAN" | tr '[:upper:]' '[:lower:]')"
+    RELEASE_ACCEPTANCE_TEST=$(get_env release-acceptance-test)
+    RELEASE_ACCEPTANCE_TEST="$(echo "$RELEASE_ACCEPTANCE_TEST" | tr '[:upper:]' '[:lower:]')"
     #  Build images
     export PIPELINE_USERNAME=$(get_env ibmcloud-api-user)
     export PIPELINE_PASSWORD=$(get_env ibmcloud-api-key-staging)
@@ -234,8 +252,19 @@ containerize:
     echo "skopeo version"
     skopeo --version || exit 1
 
+    BUILD_RELEASE_TARGET_FROM_KNOWN_IMAGES="false"
     if [[ ! -z "$PERIODIC_SCAN" && "$PERIODIC_SCAN" != "false" && "$PERIODIC_SCAN" != "no"  ]]; then
-      echo "Skipping containerize, but generating list of images. This is a periodic run that is only meant to produce CVE information."
+      echo "This is a periodic run that is only meant to produce CVE information."
+      BUILD_RELEASE_TARGET_FROM_KNOWN_IMAGES="true"
+    fi
+
+    if [[ ! -z "$RELEASE_ACCEPTANCE_TEST" && "$RELEASE_ACCEPTANCE_TEST" != "false" && "$RELEASE_ACCEPTANCE_TEST" != "no"  ]]; then
+      echo "This run is for a release acceptance test only."
+      BUILD_RELEASE_TARGET_FROM_KNOWN_IMAGES="true"
+    fi
+
+    if [[ "$BUILD_RELEASE_TARGET_FROM_KNOWN_IMAGES" == "true" ]]; then
+      echo "Skipping containerize, but generating list of images."
       RELEASE_TARGET=$(curl --silent "https://api.github.com/repos/WASdev/websphere-liberty-operator/releases/latest" | jq -r .tag_name)
       #RELEASE_TARGET=$(get_env branch)
     else
@@ -428,6 +457,16 @@ sign-artifact:
       exit 0
     fi
 
+    RELEASE_ACCEPTANCE_TEST=$(get_env release-acceptance-test)
+    RELEASE_ACCEPTANCE_TEST="$(echo "$RELEASE_ACCEPTANCE_TEST" | tr '[:upper:]' '[:lower:]')"
+
+    if [[ ! -z "$RELEASE_ACCEPTANCE_TEST" && "$RELEASE_ACCEPTANCE_TEST" != "false" && "$RELEASE_ACCEPTANCE_TEST" != "no"  ]]; then
+      echo "Skipping sign-artifact. This run is for a release acceptance test only."
+      exit 0
+    fi
+
+
+
 deploy:
   image: icr.io/continuous-delivery/pipeline/pipeline-base-ubi:3.12
   script: |
@@ -470,6 +509,14 @@ dynamic-scan:
 
     if [[ ! -z "$SKIP_SCANS" && "$SKIP_SCANS" != "false" && "$SKIP_SCANS" != "no"  ]]; then
       echo "Skipping static-scan. This is a test run only"
+      exit 0
+    fi
+    
+    RELEASE_ACCEPTANCE_TEST=$(get_env release-acceptance-test)
+    RELEASE_ACCEPTANCE_TEST="$(echo "$RELEASE_ACCEPTANCE_TEST" | tr '[:upper:]' '[:lower:]')"
+
+    if [[ ! -z "$RELEASE_ACCEPTANCE_TEST" && "$RELEASE_ACCEPTANCE_TEST" != "false" && "$RELEASE_ACCEPTANCE_TEST" != "no"  ]]; then
+      echo "Skipping dynamic-scan. This run is for a release acceptance test only."
       exit 0
     fi
 
@@ -536,6 +583,14 @@ scan-artifact:
       echo "Skipping static-scan. This is a test run only"
       exit 0
     fi
+    
+    RELEASE_ACCEPTANCE_TEST=$(get_env release-acceptance-test)
+    RELEASE_ACCEPTANCE_TEST="$(echo "$RELEASE_ACCEPTANCE_TEST" | tr '[:upper:]' '[:lower:]')"
+
+    if [[ ! -z "$RELEASE_ACCEPTANCE_TEST" && "$RELEASE_ACCEPTANCE_TEST" != "false" && "$RELEASE_ACCEPTANCE_TEST" != "no"  ]]; then
+      echo "Skipping scan-artifact. This run is for a release acceptance test only."
+      exit 0
+    fi
 
     # ========== Security Scanner ==========
     ./scripts/pipeline/ci_to_secure_pipeline_scan.sh
@@ -561,6 +616,14 @@ release:
 
     if [[ ! -z "$SKIP_SCANS" && "$SKIP_SCANS" != "false" && "$SKIP_SCANS" != "no"  ]]; then
       echo "Skipping static-scan. This is a test run only"
+      exit 0
+    fi
+
+    RELEASE_ACCEPTANCE_TEST=$(get_env release-acceptance-test)
+    RELEASE_ACCEPTANCE_TEST="$(echo "$RELEASE_ACCEPTANCE_TEST" | tr '[:upper:]' '[:lower:]')"
+
+    if [[ ! -z "$RELEASE_ACCEPTANCE_TEST" && "$RELEASE_ACCEPTANCE_TEST" != "false" && "$RELEASE_ACCEPTANCE_TEST" != "no"  ]]; then
+      echo "Skipping release. This run is for a release acceptance test only."
       exit 0
     fi
 

--- a/scripts/acceptance-test.sh
+++ b/scripts/acceptance-test.sh
@@ -24,7 +24,7 @@ declare -A E2E_TESTS=(
 		--env CLUSTER_TOKEN=${CLUSTER_TOKEN} \
 		--env TRAVIS_BUILD_NUMBER=${BUILD_NUMBER} \
 		--env RELEASE_TARGET=${RELEASE_TARGET} \
-		--env CATALOG_IMAGE=${PIPELINE_REGISTRY}/${PIPELINE_OPERATOR_IMAGE}-catalog:${RELEASE_TARGET} \
+		--env CATALOG_IMAGE=${CATALOG_IMAGE} \
 		--env DEBUG_FAILURE=${DEBUG_FAILURE} \
 		--env INSTALL_MODE=${INSTALL_MODE} \
 		--env ARCHITECTURE=${ARCHITECTURE} \
@@ -63,10 +63,40 @@ done
 
 echo "****** Waiting for e2e tests to finish"
 for test in "${!E2E_TESTS[@]}"; do
-	until docker ps --all --no-trunc --filter name="^/${test}$" --format='{{.Status}}' | grep -q Exited; do
-		sleep 60
-	done
-	echo "${test} finished"
+	
+	# Establish monitoring variables
+	monitorLoop=false
+	monitorCount=1
+	monitorMax=360  # Set for 360 minutes, or 6 hours  
+
+	# wait until we are told to exit the loop either by exceeding runtime or getting an exited notice
+	until [ "$monitorLoop" = true ]; do
+	
+		# sleep 60 seconds
+        sleep 60
+        
+		# increment counter  
+        ((monitorCount++))
+
+        # check to see if we've exceeded time
+        if  (($monitorCount>$monitorMax)); then
+            monitorLoop=true
+            echo "****** The max time to wait for the e2e tests to finish has elapsed"
+        fi
+
+        # check to see if tests have completed
+        status="$(docker ps --all --no-trunc --filter name="^/${test}$" --format='{{.Status}}')" 
+        if  ( echo "${status}" | grep -q "Exited" ); then
+            monitorLoop=true
+            echo "****** The e2e tests have completed"
+        fi
+    done
+
+	#until docker ps --all --no-trunc --filter name="^/${test}$" --format='{{.Status}}' | grep -q Exited; do
+	#	sleep 60
+	#done
+	
+	echo "****** e2e test '${test}' have completed"
 	docker logs ${test}
 done
 

--- a/scripts/acceptance-test.sh
+++ b/scripts/acceptance-test.sh
@@ -67,7 +67,7 @@ for test in "${!E2E_TESTS[@]}"; do
 	# Establish monitoring variables
 	monitorLoop=false
 	monitorCount=1
-	monitorMax=360  # Set for 360 minutes, or 6 hours  
+	monitorMax=240  # Set for 240 minutes, or 4 hours  
 
 	# wait until we are told to exit the loop either by exceeding runtime or getting an exited notice
 	until [ "$monitorLoop" = true ]; do

--- a/scripts/pipeline/runTest.sh
+++ b/scripts/pipeline/runTest.sh
@@ -14,8 +14,12 @@ oc login --insecure-skip-tls-verify $clusterurl -u kubeadmin -p $token
 echo "Open Shift Console:"
 console=$(oc whoami --show-console)
 echo $console
-echo "*** after issuing oc login"
-operators/scripts/configure-cluster/configure-cluster.sh -p $token -k $(get_env ibmcloud-api-key-staging) --arch $arch -A
+echo "*** after issuing oc login" 
+RELEASE_ACCEPTANCE_TEST=$(get_env release-acceptance-test)
+if [[ ! -z "$RELEASE_ACCEPTANCE_TEST" && "$RELEASE_ACCEPTANCE_TEST" != "false" && "$RELEASE_ACCEPTANCE_TEST" != "no"  ]]; then
+  CLUSTER_CONFIG_OPTIONS=" --skip-create-icsp"
+fi
+operators/scripts/configure-cluster/configure-cluster.sh -p $token -k $(get_env ibmcloud-api-key-staging) --arch $arch -A $CLUSTER_CONFIG_OPTIONS
 
 export GO_VERSION=$(get_env go-version)
 make setup-go GO_RELEASE_VERSION=$GO_VERSION
@@ -45,8 +49,17 @@ export FYRE_PASS=$(get_env fyre-pass)
 export FYRE_PRODUCT_GROUP_ID=$(get_env fyre-product-group-id)
 
 echo "${PIPELINE_PASSWORD}" | docker login "${PIPELINE_REGISTRY}" -u "${PIPELINE_USERNAME}" --password-stdin
-IMAGE="${PIPELINE_REGISTRY}/${PIPELINE_OPERATOR_IMAGE}:${RELEASE_TARGET}"
-echo "one-pipline Image value: ${IMAGE}"
+if [[ ! -z "$RELEASE_ACCEPTANCE_TEST" && "$RELEASE_ACCEPTANCE_TEST" != "false" && "$RELEASE_ACCEPTANCE_TEST" != "no"  ]]; then
+  RELEASE_TARGET=$(curl --silent "https://api.github.com/repos/WASdev/websphere-liberty-operator/releases/latest" | jq -r .tag_name)
+  PIPELINE_PRODUCTION_IMAGE=$(get_env pipeline-production-image)
+  IMAGE="${PIPELINE_PRODUCTION_IMAGE}:${RELEASE_TARGET}"
+  export CATALOG_IMAGE="${PIPELINE_PRODUCTION_IMAGE}-catalog:${RELEASE_TARGET}"
+else
+  IMAGE="${PIPELINE_REGISTRY}/${PIPELINE_OPERATOR_IMAGE}:${RELEASE_TARGET}"
+  export CATALOG_IMAGE="${PIPELINE_REGISTRY}/${PIPELINE_OPERATOR_IMAGE}-catalog:${RELEASE_TARGET}"
+fi
+echo "one-pipeline Image value: ${IMAGE}"
+echo "one-pipeline Catalog Image value: ${CATALOG_IMAGE}"
 DIGEST="$(skopeo inspect docker://$IMAGE | grep Digest | grep -o 'sha[^\"]*')"
 
 export DIGEST


### PR DESCRIPTION
This PR adds the ability to run a pipeline-build to test the latest release driver.  Setting the option `release-acceptance-test` will set the build to perform this task.  Beyond this capability a new time out option has been added to the acceptance test stanza.  This timeout will trigger the test to stop and gather logs prior to one-pipeline ending the build without logs.