### PR TITLE
env_id required

### DIFF
--- a/scripts/pipeline/runTest.sh
+++ b/scripts/pipeline/runTest.sh
@@ -79,7 +79,7 @@ else
     curl -X POST -H 'Content-type: application/json' --data '{"text":"<'$user'>  accceptance test failure see below "}' $(get_env slack_web_hook_url)
     echo " "
     done
-    pipeline_url="https://cloud.ibm.com/devops/pipelines/tekton/${PIPELINE_ID}/runs/${PIPELINE_RUN_ID}"
+    pipeline_url="https://cloud.ibm.com/devops/pipelines/tekton/${PIPELINE_ID}/runs/${PIPELINE_RUN_ID}?env_id=ibm:yp:us-south"
     curl -X POST -H 'Content-type: application/json' --data '{"text":"Your acceptance test failed."}' $(get_env slack_web_hook_url) </dev/null
     curl -X POST -H 'Content-type: application/json' --data '{"text":"Failing pipeline: '$pipeline_url'"}' $(get_env slack_web_hook_url) </dev/null
     curl -X POST -H 'Content-type: application/json' --data '{"text":"The cluster will be retained for '$hours' hours.  If you need more time to debug ( 72 hours ):"}' $(get_env slack_web_hook_url) </dev/null


### PR DESCRIPTION
Pipeline URL without the env_id parameter is no longer working.  If you click on the link, you get a `Page Not Found`. According to the Pipeline team, env_id was always a required parameter.  Adding it to the URL so that the page is accessible.