### PR TITLE
Add service certificate annotations Kuttl tests

### DIFF
--- a/bundle/tests/scorecard/kuttl/service-certificate-annotations/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/service-certificate-annotations/00-assert.yaml
@@ -1,0 +1,35 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: service-with-cert-annotations-liberty-svc-tls-cm
+  annotations:
+    key1: value1
+spec:
+  secretName: service-with-cert-annotations-liberty-svc-tls-cm
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: service-with-cert-annotations-liberty
+status:
+  replicas: 1
+  readyReplicas: 1
+  updatedReplicas: 1
+spec:
+  template:
+    spec:
+      containers:
+      - env:
+        - name: TLS_DIR
+          value: /etc/x509/certs
+        - name: SA_RESOURCE_VERSION
+        - name: SERVICE_CERT_SECRET_RESOURCE_VERSION
+        volumeMounts:
+        - name: svc-certificate
+          mountPath: /etc/x509/certs
+          readOnly: true
+      volumes:
+      - name: svc-certificate
+        secret:
+          defaultMode: 420
+          secretName: service-with-cert-annotations-liberty-svc-tls-cm

--- a/bundle/tests/scorecard/kuttl/service-certificate-annotations/00-wl-with-cert-annotations.yaml
+++ b/bundle/tests/scorecard/kuttl/service-certificate-annotations/00-wl-with-cert-annotations.yaml
@@ -1,0 +1,13 @@
+apiVersion: liberty.websphere.ibm.com/v1
+kind: WebSphereLibertyApplication
+metadata:
+  name: service-with-cert-annotations-liberty
+spec:
+  license:
+    accept: true
+  applicationImage: icr.io/appcafe/websphere-liberty:full-java8-openj9-ubi
+  replicas: 1
+  service:
+    certificate:
+      annotations:
+        key1: "value1"

--- a/bundle/tests/scorecard/kuttl/service-certificate-annotations/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/service-certificate-annotations/01-assert.yaml
@@ -1,0 +1,36 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: service-with-cert-annotations-liberty-svc-tls-cm
+  annotations:
+    key1: "value1"
+    key2: "value2"
+spec:
+  secretName: service-with-cert-annotations-liberty-svc-tls-cm
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: service-with-cert-annotations-liberty
+status:
+  replicas: 1
+  readyReplicas: 1
+  updatedReplicas: 1
+spec:
+  template:
+    spec:
+      containers:
+      - env:
+        - name: TLS_DIR
+          value: /etc/x509/certs
+        - name: SA_RESOURCE_VERSION
+        - name: SERVICE_CERT_SECRET_RESOURCE_VERSION
+        volumeMounts:
+        - name: svc-certificate
+          mountPath: /etc/x509/certs
+          readOnly: true
+      volumes:
+      - name: svc-certificate
+        secret:
+          defaultMode: 420
+          secretName: service-with-cert-annotations-liberty-svc-tls-cm

--- a/bundle/tests/scorecard/kuttl/service-certificate-annotations/01-wl-update-cert-annotations.yaml
+++ b/bundle/tests/scorecard/kuttl/service-certificate-annotations/01-wl-update-cert-annotations.yaml
@@ -1,0 +1,14 @@
+apiVersion: liberty.websphere.ibm.com/v1
+kind: WebSphereLibertyApplication
+metadata:
+  name: service-with-cert-annotations-liberty
+spec:
+  license:
+    accept: true
+  applicationImage: icr.io/appcafe/websphere-liberty:full-java8-openj9-ubi
+  replicas: 1
+  service:
+    certificate:
+      annotations:
+        key1: "value1"
+        key2: "value2"

--- a/bundle/tests/scorecard/kuttl/service-certificate-annotations/02-delete.yaml
+++ b/bundle/tests/scorecard/kuttl/service-certificate-annotations/02-delete.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: liberty.websphere.ibm.com/v1
+  kind: WebSphereLibertyApplication


### PR DESCRIPTION
- Adds service certificate annotations Kuttl tests to check that annotations can be properly applied to CertManager Certificates with WLO's .spec.service.certificate.annotations

Related issue: https://github.com/WASdev/websphere-liberty-operator/issues/440