### PR TITLE
Add resource conflict Kuttl tests

### DIFF
--- a/bundle/tests/scorecard/kuttl/resource-conflict/00-abandoned-knative.yaml
+++ b/bundle/tests/scorecard/kuttl/resource-conflict/00-abandoned-knative.yaml
@@ -1,0 +1,9 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: resource-conflict-wsliberty
+  ownerReferences:
+  - apiVersion: liberty.websphere.ibm.com/v1
+    kind: NotWebSphereLibertyApplication
+    name: not-resource-conflict-wsliberty
+    uid: abcdefghijklmnopqrstuvwxyz

--- a/bundle/tests/scorecard/kuttl/resource-conflict/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/resource-conflict/00-assert.yaml
@@ -1,0 +1,8 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: resource-conflict-wsliberty
+  ownerReferences:
+  - apiVersion: liberty.websphere.ibm.com/v1
+    kind: NotWebSphereLibertyApplication
+    name: not-resource-conflict-wsliberty

--- a/bundle/tests/scorecard/kuttl/resource-conflict/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/resource-conflict/01-assert.yaml
@@ -1,0 +1,8 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: resource-conflict-wsliberty
+  ownerReferences:
+  - apiVersion: liberty.websphere.ibm.com/v1
+    kind: NotWebSphereLibertyApplication
+    name: not-resource-conflict-wsliberty

--- a/bundle/tests/scorecard/kuttl/resource-conflict/01-errors.yaml
+++ b/bundle/tests/scorecard/kuttl/resource-conflict/01-errors.yaml
@@ -1,0 +1,8 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: resource-conflict-wsliberty
+  ownerReferences:
+  - apiVersion: liberty.websphere.ibm.com/v1
+    kind: WebSphereLibertyApplication
+    name: resource-conflict-wsliberty

--- a/bundle/tests/scorecard/kuttl/resource-conflict/01-liberty-knative.yaml
+++ b/bundle/tests/scorecard/kuttl/resource-conflict/01-liberty-knative.yaml
@@ -1,0 +1,10 @@
+apiVersion: liberty.websphere.ibm.com/v1
+kind: WebSphereLibertyApplication
+metadata:
+  name: resource-conflict-wsliberty
+spec:
+  license:
+    accept: true
+  applicationImage: registry.k8s.io/pause:3.2
+  replicas: 1
+  createKnativeService: true

--- a/bundle/tests/scorecard/kuttl/resource-conflict/02-delete.yaml
+++ b/bundle/tests/scorecard/kuttl/resource-conflict/02-delete.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: liberty.websphere.ibm.com/v1
+  kind: WebSphereLibertyApplication

--- a/bundle/tests/scorecard/kuttl/resource-conflict/03-delete-knative.yaml
+++ b/bundle/tests/scorecard/kuttl/resource-conflict/03-delete-knative.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: serving.knative.dev/v1
+  kind: Service
+  name: resource-conflict-wsliberty

--- a/bundle/tests/scorecard/kuttl/resource-conflict/04-abandonded-deployment.yaml
+++ b/bundle/tests/scorecard/kuttl/resource-conflict/04-abandonded-deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: resource-conflict-wsliberty
+  ownerReferences:
+  - apiVersion: liberty.websphere.ibm.com/v1
+    kind: NotWebSphereLibertyApplication
+    name: not-resource-conflict-wsliberty
+    uid: abcdefghijklmnopqrstuvwxyz
+spec:
+  template:
+    metadata:
+      labels:
+        test: kuttl
+    spec:
+      containers:
+      - name: app
+        image: registry.k8s.io/pause:3.2
+  selector:
+    matchLabels:
+      test: kuttl
+status:
+  replicas: 1
+  readyReplicas: 1
+  updatedReplicas: 1

--- a/bundle/tests/scorecard/kuttl/resource-conflict/04-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/resource-conflict/04-assert.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: resource-conflict-wsliberty
+  ownerReferences:
+  - apiVersion: liberty.websphere.ibm.com/v1
+    kind: NotWebSphereLibertyApplication
+    name: not-resource-conflict-wsliberty
+status:
+  replicas: 1
+  readyReplicas: 1
+  updatedReplicas: 1

--- a/bundle/tests/scorecard/kuttl/resource-conflict/05-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/resource-conflict/05-assert.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: resource-conflict-wsliberty
+  ownerReferences:
+  - apiVersion: liberty.websphere.ibm.com/v1
+    kind: NotWebSphereLibertyApplication
+    name: not-resource-conflict-wsliberty
+status:
+  replicas: 1
+  readyReplicas: 1
+  updatedReplicas: 1

--- a/bundle/tests/scorecard/kuttl/resource-conflict/05-errors.yaml
+++ b/bundle/tests/scorecard/kuttl/resource-conflict/05-errors.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: resource-conflict-wsliberty
+  ownerReferences:
+  - apiVersion: liberty.websphere.ibm.com/v1
+    kind: WebSphereLibertyApplication
+    name: resource-conflict-wsliberty
+status:
+  replicas: 1
+  readyReplicas: 1
+  updatedReplicas: 1

--- a/bundle/tests/scorecard/kuttl/resource-conflict/05-liberty-deployment.yaml
+++ b/bundle/tests/scorecard/kuttl/resource-conflict/05-liberty-deployment.yaml
@@ -1,0 +1,9 @@
+apiVersion: liberty.websphere.ibm.com/v1
+kind: WebSphereLibertyApplication
+metadata:
+  name: resource-conflict-wsliberty
+spec:
+  license:
+    accept: true
+  applicationImage: registry.k8s.io/pause:3.2
+  replicas: 1

--- a/bundle/tests/scorecard/kuttl/resource-conflict/06-delete.yaml
+++ b/bundle/tests/scorecard/kuttl/resource-conflict/06-delete.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: liberty.websphere.ibm.com/v1
+  kind: WebSphereLibertyApplication

--- a/bundle/tests/scorecard/kuttl/resource-conflict/07-delete-deployment.yaml
+++ b/bundle/tests/scorecard/kuttl/resource-conflict/07-delete-deployment.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: apps/v1
+  kind: Deployment
+  name: resource-conflict-wsliberty

--- a/bundle/tests/scorecard/kuttl/resource-conflict/08-abandonded-statefulset.yaml
+++ b/bundle/tests/scorecard/kuttl/resource-conflict/08-abandonded-statefulset.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: resource-conflict-wsliberty
+  ownerReferences:
+  - apiVersion: liberty.websphere.ibm.com/v1
+    kind: NotWebSphereLibertyApplication
+    name: not-resource-conflict-wsliberty
+    uid: abcdefghijklmnopqrstuvwxyz
+spec:
+  template:
+    metadata:
+      labels:
+        test: kuttl
+    spec:
+      containers:
+      - name: app
+        image: registry.k8s.io/pause:3.2
+  selector:
+    matchLabels:
+      test: kuttl
+status:
+  replicas: 1
+  readyReplicas: 1
+  updatedReplicas: 1

--- a/bundle/tests/scorecard/kuttl/resource-conflict/08-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/resource-conflict/08-assert.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: resource-conflict-wsliberty
+  ownerReferences:
+  - apiVersion: liberty.websphere.ibm.com/v1
+    kind: NotWebSphereLibertyApplication
+    name: not-resource-conflict-wsliberty
+status:
+  replicas: 1
+  readyReplicas: 1
+  updatedReplicas: 1

--- a/bundle/tests/scorecard/kuttl/resource-conflict/09-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/resource-conflict/09-assert.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: resource-conflict-wsliberty
+  ownerReferences:
+  - apiVersion: liberty.websphere.ibm.com/v1
+    kind: NotWebSphereLibertyApplication
+    name: not-resource-conflict-wsliberty
+status:
+  replicas: 1
+  readyReplicas: 1
+  updatedReplicas: 1

--- a/bundle/tests/scorecard/kuttl/resource-conflict/09-errors.yaml
+++ b/bundle/tests/scorecard/kuttl/resource-conflict/09-errors.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: resource-conflict-wsliberty
+  ownerReferences:
+  - apiVersion: liberty.websphere.ibm.com/v1
+    kind: WebSphereLibertyApplication
+    name: resource-conflict-wsliberty
+status:
+  replicas: 1
+  readyReplicas: 1
+  updatedReplicas: 1

--- a/bundle/tests/scorecard/kuttl/resource-conflict/09-liberty-statefulset.yaml
+++ b/bundle/tests/scorecard/kuttl/resource-conflict/09-liberty-statefulset.yaml
@@ -1,0 +1,10 @@
+apiVersion: liberty.websphere.ibm.com/v1
+kind: WebSphereLibertyApplication
+metadata:
+  name: resource-conflict-wsliberty
+spec:
+  license:
+    accept: true
+  applicationImage: registry.k8s.io/pause:3.2
+  replicas: 1
+  statefulSet: {}

--- a/bundle/tests/scorecard/kuttl/resource-conflict/10-delete.yaml
+++ b/bundle/tests/scorecard/kuttl/resource-conflict/10-delete.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: liberty.websphere.ibm.com/v1
+  kind: WebSphereLibertyApplication

--- a/bundle/tests/scorecard/kuttl/resource-conflict/11-delete-statefulset.yaml
+++ b/bundle/tests/scorecard/kuttl/resource-conflict/11-delete-statefulset.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: apps/v1
+  kind: StatefulSet
+  name: resource-conflict-wsliberty

--- a/config/rbac/kind-kuttl-rbac.yaml
+++ b/config/rbac/kind-kuttl-rbac.yaml
@@ -89,6 +89,8 @@ rules:
   - services
   verbs:
   - get
+  - create
+  - delete
 - apiGroups:
   - liberty.websphere.ibm.com
   resources:


### PR DESCRIPTION
- Add Kuttl tests to check for resource conflicts with knative service, deployment and statefulsets. 

Related issue https://github.com/WASdev/websphere-liberty-operator/issues/442