### PR TITLE
Updates for WLO 1.2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 ARG USER_ID=65532
 ARG GROUP_ID=65532
 
-ARG VERSION_LABEL=1.2.1
+ARG VERSION_LABEL=1.2.2
 ARG RELEASE_LABEL=XX
 ARG VCS_REF=0123456789012345678901234567890123456789
 ARG VCS_URL="https://github.com/WASdev/websphere-liberty-operator"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.2.1
+VERSION ?= 1.2.2
 OPERATOR_SDK_RELEASE_VERSION ?= v1.24.0
 
 # CHANNELS define the bundle channels used in the bundle.

--- a/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
@@ -11,7 +11,7 @@ metadata:
             "name": "websphereliberty-app-sample"
           },
           "spec": {
-            "applicationImage": "icr.io/appcafe/open-liberty/samples/getting-started@sha256:d3c67c4a15c97b0fb82f9ef4a2ccf474232b878787e9eea39af75a3ac78469e3",
+            "applicationImage": "icr.io/appcafe/open-liberty/samples/getting-started@sha256:e32f0eb0feff73c6bc8416fe2f7aa0cb74cbaa325cae5fad636325ee0ac4a105",
             "expose": true,
             "license": {
               "accept": false,
@@ -59,7 +59,7 @@ metadata:
     capabilities: Auto Pilot
     categories: Application Runtime
     containerImage: icr.io/cpopen/websphere-liberty-operator:daily
-    createdAt: "2023-07-31T14:54:26Z"
+    createdAt: "2023-07-31T18:03:44Z"
     description: Deploy and manage containerized Liberty applications
     olm.skipRange: '>=1.0.0 <1.2.2'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
@@ -859,7 +859,7 @@ spec:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: RELATED_IMAGE_LIBERTY_SAMPLE_APP
-                  value: icr.io/appcafe/open-liberty/samples/getting-started@sha256:d3c67c4a15c97b0fb82f9ef4a2ccf474232b878787e9eea39af75a3ac78469e3
+                  value: icr.io/appcafe/open-liberty/samples/getting-started@sha256:e32f0eb0feff73c6bc8416fe2f7aa0cb74cbaa325cae5fad636325ee0ac4a105
                 image: icr.io/cpopen/websphere-liberty-operator:daily
                 livenessProbe:
                   failureThreshold: 3
@@ -1132,6 +1132,6 @@ spec:
   provider:
     name: IBM
   relatedImages:
-  - image: icr.io/appcafe/open-liberty/samples/getting-started@sha256:d3c67c4a15c97b0fb82f9ef4a2ccf474232b878787e9eea39af75a3ac78469e3
+  - image: icr.io/appcafe/open-liberty/samples/getting-started@sha256:e32f0eb0feff73c6bc8416fe2f7aa0cb74cbaa325cae5fad636325ee0ac4a105
     name: liberty-sample-app
   version: 1.2.2

--- a/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
@@ -59,9 +59,9 @@ metadata:
     capabilities: Auto Pilot
     categories: Application Runtime
     containerImage: icr.io/cpopen/websphere-liberty-operator:daily
-    createdAt: "2023-06-26T17:52:19Z"
+    createdAt: "2023-07-31T14:54:26Z"
     description: Deploy and manage containerized Liberty applications
-    olm.skipRange: '>=1.0.0 <1.2.1'
+    olm.skipRange: '>=1.0.0 <1.2.2'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.24.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -72,7 +72,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: ibm-websphere-liberty.v1.2.1
+  name: ibm-websphere-liberty.v1.2.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1134,4 +1134,4 @@ spec:
   relatedImages:
   - image: icr.io/appcafe/open-liberty/samples/getting-started@sha256:d3c67c4a15c97b0fb82f9ef4a2ccf474232b878787e9eea39af75a3ac78469e3
     name: liberty-sample-app
-  version: 1.2.1
+  version: 1.2.2

--- a/bundle/tests/scorecard/kuttl/basic/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/basic/00-assert.yaml
@@ -13,5 +13,5 @@ metadata:
   name: my-wsliberty-app
 status:
   versions:
-    reconciled: 1.2.1
+    reconciled: 1.2.2
 

--- a/bundle/tests/scorecard/kuttl/dump/01-dump.yaml
+++ b/bundle/tests/scorecard/kuttl/dump/01-dump.yaml
@@ -10,4 +10,4 @@ spec:
     - thread
     - heap
   versions:
-    reconciled: 1.2.1
+    reconciled: 1.2.2

--- a/bundle/tests/scorecard/kuttl/trace/01-trace.yaml
+++ b/bundle/tests/scorecard/kuttl/trace/01-trace.yaml
@@ -10,4 +10,4 @@ spec:
   maxFileSize: 20
   maxFiles: 5
   versions:
-    reconciled: 1.2.1
+    reconciled: 1.2.2

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -72,7 +72,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.annotations['olm.targetNamespaces']
           - name: RELATED_IMAGE_LIBERTY_SAMPLE_APP
-            value: icr.io/appcafe/open-liberty/samples/getting-started@sha256:d3c67c4a15c97b0fb82f9ef4a2ccf474232b878787e9eea39af75a3ac78469e3
+            value: icr.io/appcafe/open-liberty/samples/getting-started@sha256:e32f0eb0feff73c6bc8416fe2f7aa0cb74cbaa325cae5fad636325ee0ac4a105
         securityContext:
           allowPrivilegeEscalation: false
           privileged: false

--- a/config/manifests/bases/ibm-websphere-liberty.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-websphere-liberty.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Application Runtime
     createdAt: "2021-11-25T14:00:00Z"
     description: Deploy and manage containerized Liberty applications
-    olm.skipRange: '>=1.0.0 <1.2.1'
+    olm.skipRange: '>=1.0.0 <1.2.2'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     repository: https://github.com/WASdev/websphere-liberty-operator
     support: IBM

--- a/config/samples/liberty.websphere.ibm.com_v1_webspherelibertyapplications.yaml
+++ b/config/samples/liberty.websphere.ibm.com_v1_webspherelibertyapplications.yaml
@@ -7,7 +7,7 @@ spec:
     accept: false
     edition: IBM WebSphere Application Server
     productEntitlementSource: Standalone
-  applicationImage: icr.io/appcafe/open-liberty/samples/getting-started@sha256:d3c67c4a15c97b0fb82f9ef4a2ccf474232b878787e9eea39af75a3ac78469e3
+  applicationImage: icr.io/appcafe/open-liberty/samples/getting-started@sha256:e32f0eb0feff73c6bc8416fe2f7aa0cb74cbaa325cae5fad636325ee0ac4a105
   expose: true
   manageTLS: true
   replicas: 1

--- a/index.Dockerfile
+++ b/index.Dockerfile
@@ -2,7 +2,7 @@ FROM registry.redhat.io/openshift4/ose-operator-registry:v4.12 AS builder
 
 FROM registry.redhat.io/ubi8/ubi-minimal
 
-ARG VERSION_LABEL=1.2.1
+ARG VERSION_LABEL=1.2.2
 ARG RELEASE_LABEL=XX
 ARG VCS_REF=0123456789012345678901234567890123456789
 ARG VCS_URL="https://github.com/WASdev/websphere-liberty-operator"

--- a/internal/deploy/kubectl/websphereliberty-app-operator.yaml
+++ b/internal/deploy/kubectl/websphereliberty-app-operator.yaml
@@ -305,7 +305,7 @@ spec:
         - name: WATCH_NAMESPACE
           value: WEBSPHERE_LIBERTY_WATCH_NAMESPACE
         - name: RELATED_IMAGE_LIBERTY_SAMPLE_APP
-          value: icr.io/appcafe/open-liberty/samples/getting-started@sha256:d3c67c4a15c97b0fb82f9ef4a2ccf474232b878787e9eea39af75a3ac78469e3
+          value: icr.io/appcafe/open-liberty/samples/getting-started@sha256:e32f0eb0feff73c6bc8416fe2f7aa0cb74cbaa325cae5fad636325ee0ac4a105
         image: icr.io/cpopen/websphere-liberty-operator:daily
         livenessProbe:
           failureThreshold: 3

--- a/internal/deploy/kustomize/daily/base/websphere-liberty-deployment.yaml
+++ b/internal/deploy/kustomize/daily/base/websphere-liberty-deployment.yaml
@@ -55,7 +55,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: RELATED_IMAGE_LIBERTY_SAMPLE_APP
-          value: icr.io/appcafe/open-liberty/samples/getting-started@sha256:d3c67c4a15c97b0fb82f9ef4a2ccf474232b878787e9eea39af75a3ac78469e3
+          value: icr.io/appcafe/open-liberty/samples/getting-started@sha256:e32f0eb0feff73c6bc8416fe2f7aa0cb74cbaa325cae5fad636325ee0ac4a105
         image: cp.stg.icr.io/cp/websphere-liberty-operator:main
         livenessProbe:
           failureThreshold: 3

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -48,7 +48,7 @@ var log = logf.Log.WithName("websphereliberty_utils")
 // Constant Values
 const serviceabilityMountPath = "/serviceability"
 const ssoEnvVarPrefix = "SEC_SSO_"
-const OperandVersion = "1.2.1"
+const OperandVersion = "1.2.2"
 
 var editionProductID = map[wlv1.LicenseEdition]string{
 	wlv1.LicenseEditionBase: "e7daacc46bbe4e2dacd2af49145a4723",


### PR DESCRIPTION
- Update operator version to 1.2.2
- Update the reconciled version in tests (basic, trace and dump)
- Update getting-started sample app reference

PR for https://github.com/WASdev/websphere-liberty-operator/issues/524