### PR TITLE
523: only retain ocp cluster when e2e test fail

### DIFF
--- a/scripts/acceptance-test.sh
+++ b/scripts/acceptance-test.sh
@@ -103,12 +103,24 @@ done
 echo "****** Test results"
 exit_code=0
 for test in "${!E2E_TESTS[@]}"; do
+    if [[ "${test}" == "kind-e2e-run" ]]; then
+        TEST_ID=$KIND_E2E_TEST;
+    elif [[ "${test}" == "ocp-e2e-run-X" ]]; then
+        TEST_ID=$OCP_E2E_X_TEST;
+    elif [[ "${test}" == "ocp-e2e-run-P" ]]; then
+        TEST_ID=$OCP_E2E_P_TEST;
+    elif [[ "${test}" == "ocp-e2e-run-Z" ]]; then
+        TEST_ID=$OCP_E2E_Z_TEST;
+	else
+	    TEST_ID=$UNKNOWN_E2E_TEST
+    fi
+
 	status="$(docker ps --all --no-trunc --filter name="^/${test}$" --format='{{.Status}}')"
 	if echo "${status}" | grep -q "Exited (0)"; then
 		echo "[PASSED] ${test}"
 	else
 		echo "[FAILED] ${test}: ${status}"
-		exit_code=1
+		exit_code=$((exit_code + $TEST_ID))
 	fi
 done
 exit ${exit_code}

--- a/scripts/pipeline/runTest.sh
+++ b/scripts/pipeline/runTest.sh
@@ -91,6 +91,19 @@ echo "switching back to ebc-gateway-http directory"
 cd scripts/pipeline/ebc-gateway-http
 
 if [[ "$keep_cluster" == 0 ]]; then
+    if (( (rc & KIND_E2E_TEST) >0 )); then
+      slack_users=$(get_env slack_users)
+      echo "slack_users=$slack_users"
+      eval "arr=($slack_users)"
+      for user in "${arr[@]}"; do 
+        echo "user=$user"
+        curl -X POST -H 'Content-type: application/json' --data '{"text":"<'$user'>  kind accceptance test failure see below "}' $(get_env slack_web_hook_url)
+        echo " "
+      done
+      pipeline_url="https://cloud.ibm.com/devops/pipelines/tekton/${PIPELINE_ID}/runs/${PIPELINE_RUN_ID}?env_id=ibm:yp:us-south"
+      curl -X POST -H 'Content-type: application/json' --data '{"text":"Your kind acceptance test failed."}' $(get_env slack_web_hook_url) </dev/null
+      curl -X POST -H 'Content-type: application/json' --data '{"text":"Failing pipeline: '$pipeline_url'"}' $(get_env slack_web_hook_url) </dev/null
+    fi
     ./ebc_complete.sh
 else
     hours=$(get_env ebc_autocomplete_hours "6")
@@ -103,9 +116,9 @@ else
     echo "slack_users=$slack_users"
     eval "arr=($slack_users)"
     for user in "${arr[@]}"; do 
-    echo "user=$user"
-    curl -X POST -H 'Content-type: application/json' --data '{"text":"<'$user'>  accceptance test failure see below "}' $(get_env slack_web_hook_url)
-    echo " "
+      echo "user=$user"
+      curl -X POST -H 'Content-type: application/json' --data '{"text":"<'$user'>  accceptance test failure see below "}' $(get_env slack_web_hook_url)
+      echo " "
     done
     pipeline_url="https://cloud.ibm.com/devops/pipelines/tekton/${PIPELINE_ID}/runs/${PIPELINE_RUN_ID}?env_id=ibm:yp:us-south"
     curl -X POST -H 'Content-type: application/json' --data '{"text":"Your acceptance test failed."}' $(get_env slack_web_hook_url) </dev/null

--- a/scripts/pipeline/runTest.sh
+++ b/scripts/pipeline/runTest.sh
@@ -48,6 +48,13 @@ export FYRE_KEY=$(get_env fyre-key)
 export FYRE_PASS=$(get_env fyre-pass)
 export FYRE_PRODUCT_GROUP_ID=$(get_env fyre-product-group-id)
 
+# acceptance-test.sh return values
+export KIND_E2E_TEST=1
+export OCP_E2E_X_TEST=2
+export OCP_E2E_P_TEST=4
+export OCP_E2E_Z_TEST=8
+export UNKNOWN_E2E_TEST=256
+
 echo "${PIPELINE_PASSWORD}" | docker login "${PIPELINE_REGISTRY}" -u "${PIPELINE_USERNAME}" --password-stdin
 if [[ ! -z "$RELEASE_ACCEPTANCE_TEST" && "$RELEASE_ACCEPTANCE_TEST" != "false" && "$RELEASE_ACCEPTANCE_TEST" != "no"  ]]; then
   RELEASE_TARGET=$(curl --silent "https://api.github.com/repos/WASdev/websphere-liberty-operator/releases/latest" | jq -r .tag_name)
@@ -71,11 +78,19 @@ pwd
 
 scripts/acceptance-test.sh
 rc=$?
+keep_cluster=0
+
+if (( (rc & OCP_E2E_X_TEST) >0 )) || 
+   (( (rc & OCP_E2E_P_TEST) >0 )) ||
+   (( (rc & OCP_E2E_Z_TEST) >0 )) ||
+   (( (rc & UNKNOWN_E2E_TEST) >0 )); then
+   keep_cluster=1
+fi
 
 echo "switching back to ebc-gateway-http directory"
 cd scripts/pipeline/ebc-gateway-http
 
-if [[ "$rc" == 0 ]]; then
+if [[ "$keep_cluster" == 0 ]]; then
     ./ebc_complete.sh
 else
     hours=$(get_env ebc_autocomplete_hours "6")


### PR DESCRIPTION
Add logic in test scripting to pass back knowledge of which tests have failed during the acceptance test phase of the build.  This allows a decision to be made as to whether or not to retain the cluster.