### PR TITLE
Skip the new detect-serets stage

### DIFF
--- a/.one-pipeline-archive.yaml
+++ b/.one-pipeline-archive.yaml
@@ -31,6 +31,16 @@ setup:
       echo "${REPO} has been archived successfully to ${ARCHIVE_DESTINATION_REPO}"
     fi
     
+detect-secrets:
+  image: icr.io/continuous-delivery/pipeline/pipeline-base-ubi:3.12
+  abort_on_failure: false
+  image_pull_policy: IfNotPresent
+  skip: true
+  script: |
+    #!/usr/bin/env bash
+    echo "Skip detect-secrets"
+    exit 0
+    
 test:
   dind: true
   abort_on_failure: false

--- a/.one-pipeline.yaml
+++ b/.one-pipeline.yaml
@@ -78,6 +78,16 @@ setup:
         fi 
     fi
     
+detect-secrets:
+  image: icr.io/continuous-delivery/pipeline/pipeline-base-ubi:3.12
+  abort_on_failure: false
+  image_pull_policy: IfNotPresent
+  skip: true
+  script: |
+    #!/usr/bin/env bash
+    echo "Skipping detect-secrets as it's already run as part of code-compliance-checks"
+    exit 0
+    
 test:
   dind: true
   abort_on_failure: true


### PR DESCRIPTION
detect-serets is already run as part of code-compliance-checks stage, so skip the new detect-secrets stage