### PR TITLE
Bug fix: create default service account if name not specified

### DIFF
--- a/controllers/webspherelibertyapplication_controller.go
+++ b/controllers/webspherelibertyapplication_controller.go
@@ -247,7 +247,7 @@ func (r *ReconcileWebSphereLiberty) Reconcile(ctx context.Context, request ctrl.
 		}
 	}
 
-	if instance.Spec.ServiceAccountName == nil || *instance.Spec.ServiceAccountName == "" {
+	if oputils.GetServiceAccountName(instance) == "" {
 		serviceAccount := &corev1.ServiceAccount{ObjectMeta: defaultMeta}
 		err = r.CreateOrUpdate(serviceAccount, instance, func() error {
 			return oputils.CustomizeServiceAccount(serviceAccount, instance, r.GetClient())


### PR DESCRIPTION
The previous change to deprecate .spec.ServiceAccountName was not reflected in the controller where the default service account is created. Use the new utils method to check if a service account has been specified before creating the default account

This change was missed from the initial fix for
https://github.com/OpenLiberty/open-liberty-operator/issues/462