### PR TITLE
Add PodAntiAffinity based on host/node to Semeru compiler

### DIFF
--- a/controllers/semeru_compiler.go
+++ b/controllers/semeru_compiler.go
@@ -313,7 +313,7 @@ func (r *ReconcileWebSphereLiberty) reconcileSemeruDeployment(wlva *wlv1.WebSphe
 								TopologyKey: "topology.kubernetes.io/zone",
 								LabelSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
-										"app.kubernetes.io/name": getSemeruCompilerName(wlva),
+										"app.kubernetes.io/name": getSemeruCompilerNameWithGeneration(wlva),
 									},
 								},
 							},
@@ -324,7 +324,7 @@ func (r *ReconcileWebSphereLiberty) reconcileSemeruDeployment(wlva *wlv1.WebSphe
 								TopologyKey: "kubernetes.io/hostname",
 								LabelSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
-										"app.kubernetes.io/instance": getSemeruCompilerName(wlva),
+										"app.kubernetes.io/instance": getSemeruCompilerNameWithGeneration(wlva),
 									},
 								},
 							},

--- a/controllers/semeru_compiler.go
+++ b/controllers/semeru_compiler.go
@@ -313,7 +313,7 @@ func (r *ReconcileWebSphereLiberty) reconcileSemeruDeployment(wlva *wlv1.WebSphe
 								TopologyKey: "topology.kubernetes.io/zone",
 								LabelSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
-										"app.kubernetes.io/name": getSemeruCompilerNameWithGeneration(wlva),
+										"app.kubernetes.io/instance": getSemeruCompilerNameWithGeneration(wlva),
 									},
 								},
 							},

--- a/controllers/semeru_compiler.go
+++ b/controllers/semeru_compiler.go
@@ -318,6 +318,17 @@ func (r *ReconcileWebSphereLiberty) reconcileSemeruDeployment(wlva *wlv1.WebSphe
 								},
 							},
 						},
+						{
+							Weight: 50,
+							PodAffinityTerm: corev1.PodAffinityTerm{
+								TopologyKey: "kubernetes.io/hostname",
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"app.kubernetes.io/instance": getSemeruCompilerName(wlva),
+									},
+								},
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
- Add PodAntiAffinity based on host/node to Semeru compiler
- Update to use `"app.kubernetes.io/instance"` label instead of `"app.kubernetes.io/name"`