### PR TITLE
Checkout whether serviceability has been set for dump and trace

### DIFF
--- a/controllers/webspherelibertydump_controller.go
+++ b/controllers/webspherelibertydump_controller.go
@@ -108,7 +108,7 @@ func (r *ReconcileWebSphereLibertyDump) Reconcile(ctx context.Context, request c
 	time := time.Now()
 	dumpFolder := "/serviceability/" + pod.Namespace + "/" + pod.Name
 	dumpFileName := dumpFolder + "/" + time.Format("2006-01-02_15:04:05") + ".zip"
-	dumpCmd := "mkdir -p " + dumpFolder + " &&  server dump --archive=" + dumpFileName
+	dumpCmd := "if [ ! -d \"serviceability\" ]; then exit 1; fi && " + "mkdir -p " + dumpFolder + " &&  server dump --archive=" + dumpFileName
 	if len(instance.Spec.Include) > 0 {
 		dumpCmd += " --include="
 		for i := range instance.Spec.Include {

--- a/controllers/webspherelibertytrace_controller.go
+++ b/controllers/webspherelibertytrace_controller.go
@@ -158,7 +158,7 @@ func (r *ReconcileWebSphereLibertyTrace) Reconcile(ctx context.Context, request 
 		}
 		traceConfig += "/></server>"
 
-		_, err = lutils.ExecuteCommandInContainer(r.RestConfig, podName, podNamespace, "app", []string{"/bin/sh", "-c", "mkdir -p " + traceOutputDir + " && echo '" + traceConfig + "' > " + traceConfigFile})
+		_, err = lutils.ExecuteCommandInContainer(r.RestConfig, podName, podNamespace, "app", []string{"/bin/sh", "-c", "if [ ! -d \"serviceability\" ]; then exit 1; fi && " + "mkdir -p " + traceOutputDir + " && echo '" + traceConfig + "' > " + traceConfigFile})
 		if err != nil {
 			reqLogger.Error(err, "Encountered error while setting up trace for pod "+podName+" in namespace "+podNamespace)
 			return r.UpdateStatus(err, webspherelibertyv1.OperationStatusConditionTypeEnabled, *instance, corev1.ConditionFalse, podName, podChanged)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -125,7 +125,11 @@ func ExecuteCommandInContainer(config *rest.Config, podName, podNamespace, conta
 	})
 
 	if err != nil {
-		return stderr.String(), fmt.Errorf("Encountered error while running command: %v ; Stderr: %v ; Error: %v", command, stderr.String(), err.Error())
+		if strings.Contains(err.Error(), "command terminated with exit code 1") {
+			return stderr.String(), fmt.Errorf("Unable to find serviceability directory. Please check that serviceability has been configured correctly in the relevant WebsphereLibertyApplication custom resource for pod: %v in namespace: %v.", podName, podNamespace)
+		} else {
+			return stderr.String(), fmt.Errorf("Encountered error while running command: %v ; Stderr: %v ; Error: %v", command, stderr.String(), err.Error())
+		}
 	}
 
 	return stderr.String(), nil


### PR DESCRIPTION
* Ensure that serviceability has been set on the Websphere Liberty application by checking that the "serviceability" directory has been created before a dump or trace is taken and output a suitable error message if it hasn't