### PR TITLE
fix install-go script

### DIFF
--- a/scripts/installers/install-go.sh
+++ b/scripts/installers/install-go.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
 set -o errexit
-set -o nounset
 
 main() {
     DEFAULT_RELEASE_VERSION="$(grep '^go [0-9]\+.[0-9]\+' go.mod | cut -d ' ' -f 2)"
-    RELEASE_VERSION=${1:-$DEFAULT_RELEASE_VERSION}
+    RELEASE_VERSION=$(wget --no-verbose "https://go.dev/dl/?mode=json&include=$DEFAULT_RELEASE_VERSION" -O - | jq '.[0].version' | sed -e 's#"##g')
+    if [ -n "$1" ]; then
+        RELEASE_VERSION="go$1"
+    fi
 
     if [[ -x "$(command -v go)" ]]; then
         if go version | grep -q "$RELEASE_VERSION"; then
@@ -16,14 +18,15 @@ main() {
         fi
     fi
 
+
     if [[ "$(uname)" = "Darwin" ]]; then
-        binary_url="https://golang.org/dl/go${RELEASE_VERSION}.darwin-amd64.tar.gz"
+        binary_url="https://golang.org/dl/${RELEASE_VERSION}.darwin-amd64.tar.gz"
     elif [[ "$(uname -p)" = "s390x" ]]; then
-        binary_url="https://golang.org/dl/go${RELEASE_VERSION}.linux-s390x.tar.gz"
+        binary_url="https://golang.org/dl/${RELEASE_VERSION}.linux-s390x.tar.gz"
     elif [[ "$(uname -p)" = "ppc64le" ]]; then
-        binary_url="https://golang.org/dl/go${RELEASE_VERSION}.linux-ppc64le.tar.gz"
+        binary_url="https://golang.org/dl/${RELEASE_VERSION}.linux-ppc64le.tar.gz"
     else
-        binary_url="https://golang.org/dl/go${RELEASE_VERSION}.linux-amd64.tar.gz"
+        binary_url="https://golang.org/dl/${RELEASE_VERSION}.linux-amd64.tar.gz"
     fi
 
     echo "****** Installing Go version $RELEASE_VERSION on $(uname)"


### PR DESCRIPTION
From go1.21 onwards, go no longer provides a package with no patch version in the name. Fix the script to always add a patch version

Otherwise, running the script with no arguments will fail.