### PR TITLE
Use imageReference over applicationImage in LTPA Job

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -696,7 +696,7 @@ func CustomizeLTPAJob(job *v1.Job, la *wlv1.WebSphereLibertyApplication, ltpaSec
 	job.Spec.Template.Spec.Containers = []corev1.Container{
 		{
 			Name:            job.Spec.Template.ObjectMeta.Name,
-			Image:           la.GetApplicationImage(),
+			Image:           la.GetStatus().GetImageReference(),
 			ImagePullPolicy: *la.GetPullPolicy(),
 			SecurityContext: rcoutils.GetSecurityContext(la),
 			Command:         []string{"/bin/bash", "-c"},


### PR DESCRIPTION
LTPA Manager to use `.status.imageReference` instead of `.spec.applicationImage` when passing applicationImage over to the LTPA Job.