### PR TITLE
Add ability to skip license annotations

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -57,6 +57,14 @@ const LTPAServerXMLSuffix = "-managed-ltpa-server-xml"
 const ltpaKeysFileName = "ltpa.keys"
 const ltpaXMLFileName = "managedLTPA.xml"
 
+const (
+	excludeLicenseAnnotationsKey string = "liberty.websphere.ibm.com/exclude-licensing-annotations"
+	productChargedContainersKey  string = "productChargedContainers"
+	productIDKey                 string = "productID"
+	productMetricKey             string = "productMetric"
+	productNameKey               string = "productName"
+)
+
 var editionProductID = map[wlv1.LicenseEdition]string{
 	wlv1.LicenseEditionBase: "e7daacc46bbe4e2dacd2af49145a4723",
 	wlv1.LicenseEditionCore: "87f3487c22f34742a799164f3f3ffa78",
@@ -198,12 +206,21 @@ func CustomizeLibertyAnnotations(pts *corev1.PodTemplateSpec, la *wlv1.WebSphere
 }
 
 func CustomizeLicenseAnnotations(pts *corev1.PodTemplateSpec, la *wlv1.WebSphereLibertyApplication) {
+	exclude := la.Annotations[excludeLicenseAnnotationsKey]
+	if exclude == "true" {
+		log.Info("No license annotations will be added as annotation " + excludeLicenseAnnotationsKey + " is 'true'")
+		delete(pts.Annotations, productIDKey)
+		delete(pts.Annotations, productChargedContainersKey)
+		delete(pts.Annotations, productMetricKey)
+		delete(pts.Annotations, productNameKey)
+		return
+	}
 	pid := ""
 	if val, ok := editionProductID[la.Spec.License.Edition]; ok {
 		pid = val
 	}
-	pts.Annotations["productID"] = pid
-	pts.Annotations["productChargedContainers"] = "app"
+	pts.Annotations[productIDKey] = pid
+	pts.Annotations[productChargedContainersKey] = "app"
 
 	entitlement := la.Spec.License.ProductEntitlementSource
 
@@ -211,7 +228,7 @@ func CustomizeLicenseAnnotations(pts *corev1.PodTemplateSpec, la *wlv1.WebSphere
 	if entitlement == wlv1.LicenseEntitlementWSHE || entitlement == wlv1.LicenseEntitlementCP4Apps {
 		metricValue = "VIRTUAL_PROCESSOR_CORE"
 	}
-	pts.Annotations["productMetric"] = metricValue
+	pts.Annotations[productMetricKey] = metricValue
 
 	ratio := ""
 	switch la.Spec.License.Edition {
@@ -224,7 +241,7 @@ func CustomizeLicenseAnnotations(pts *corev1.PodTemplateSpec, la *wlv1.WebSphere
 	default:
 		ratio = "4:1"
 	}
-	pts.Annotations["productName"] = string(la.Spec.License.Edition)
+	pts.Annotations[productNameKey] = string(la.Spec.License.Edition)
 
 	if entitlement == wlv1.LicenseEntitlementStandalone {
 		delete(pts.Annotations, "cloudpakName")
@@ -586,10 +603,10 @@ func Remove(list []string, s string) []string {
 
 func GetWLOLicenseAnnotations() map[string]string {
 	annotations := make(map[string]string)
-	annotations["productID"] = "cb1747ecb831410f88006195f024183f"
-	annotations["productName"] = "WebSphere Liberty Operator"
-	annotations["productMetric"] = "FREE"
-	annotations["productChargedContainers"] = "ALL"
+	annotations[productIDKey] = "cb1747ecb831410f88006195f024183f"
+	annotations[productNameKey] = "WebSphere Liberty Operator"
+	annotations[productMetricKey] = "FREE"
+	annotations[productChargedContainersKey] = "ALL"
 	return annotations
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -63,6 +63,9 @@ const (
 	productIDKey                 string = "productID"
 	productMetricKey             string = "productMetric"
 	productNameKey               string = "productName"
+	cloudPakNameKey              string = "cloudpakName"
+	cloudPakRatioKey             string = "productCloudpakRatio"
+	cloudPakIdKey                string = "cloudpakId"
 )
 
 var editionProductID = map[wlv1.LicenseEdition]string{
@@ -213,6 +216,9 @@ func CustomizeLicenseAnnotations(pts *corev1.PodTemplateSpec, la *wlv1.WebSphere
 		delete(pts.Annotations, productChargedContainersKey)
 		delete(pts.Annotations, productMetricKey)
 		delete(pts.Annotations, productNameKey)
+		delete(pts.Annotations, cloudPakNameKey)
+		delete(pts.Annotations, cloudPakRatioKey)
+		delete(pts.Annotations, cloudPakIdKey)
 		return
 	}
 	pid := ""
@@ -244,17 +250,17 @@ func CustomizeLicenseAnnotations(pts *corev1.PodTemplateSpec, la *wlv1.WebSphere
 	pts.Annotations[productNameKey] = string(la.Spec.License.Edition)
 
 	if entitlement == wlv1.LicenseEntitlementStandalone {
-		delete(pts.Annotations, "cloudpakName")
-		delete(pts.Annotations, "cloudpakId")
-		delete(pts.Annotations, "productCloudpakRatio")
+		delete(pts.Annotations, cloudPakNameKey)
+		delete(pts.Annotations, cloudPakIdKey)
+		delete(pts.Annotations, cloudPakRatioKey)
 	} else {
-		pts.Annotations["cloudpakName"] = string(entitlement)
-		pts.Annotations["productCloudpakRatio"] = ratio
+		pts.Annotations[cloudPakNameKey] = string(entitlement)
+		pts.Annotations[cloudPakRatioKey] = ratio
 		cloudpakId := ""
 		if val, ok := entitlementCloudPakID[entitlement]; ok {
 			cloudpakId = val
 		}
-		pts.Annotations["cloudpakId"] = cloudpakId
+		pts.Annotations[cloudPakIdKey] = cloudpakId
 	}
 }
 

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -385,10 +385,20 @@ func TestCustomizeLicenseAnnotations(t *testing.T) {
 
 	// Test that annotations are skipped, even where they where previously set
 	pts.Annotations[productIDKey] = editionProductID[webspherelibertyv1.LicenseEditionBase]
+	pts.Annotations[productChargedContainersKey] = "app"
+	pts.Annotations[productMetricKey] = "PROCESSOR_VALUE_UNIT"
+	pts.Annotations[productNameKey] = "random-product-name" // This doesn't need to be correct, just checking it gets removed
+	pts.Annotations[cloudPakNameKey] = "random-name"
+	pts.Annotations[cloudPakRatioKey] = "4:1"
+	pts.Annotations[cloudPakIdKey] = "random-pak-id"
 	CustomizeLicenseAnnotations(pts, app)
 	if (pts.Annotations[productIDKey] != "") || (pts.Annotations[productChargedContainersKey] != "") || (pts.Annotations[productMetricKey] != "") || (pts.Annotations[productNameKey] != "") {
 		t.Errorf("License annotations should not be set when %s is set: '%s', '%s', '%s', '%s'", excludeLicenseAnnotationsKey,
 			pts.Annotations[productIDKey], pts.Annotations[productChargedContainersKey], pts.Annotations[productMetricKey], pts.Annotations[productNameKey])
+	}
+	if (pts.Annotations[cloudPakNameKey] != "") || (pts.Annotations[cloudPakRatioKey] != "") || (pts.Annotations[cloudPakIdKey] != "") {
+		t.Errorf("Cloud pak annotations should not be set when %s is set: '%s', '%s', '%s'", excludeLicenseAnnotationsKey,
+			pts.Annotations[cloudPakNameKey], pts.Annotations[cloudPakRatioKey], pts.Annotations[cloudPakIdKey])
 	}
 
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -382,8 +382,12 @@ func TestCustomizeLicenseAnnotations(t *testing.T) {
 		t.Errorf("License annotations should not be set when %s is set: '%s', '%s', '%s', '%s'", excludeLicenseAnnotationsKey,
 			pts.Annotations[productIDKey], pts.Annotations[productChargedContainersKey], pts.Annotations[productMetricKey], pts.Annotations[productNameKey])
 	}
+	if (pts.Annotations[cloudPakNameKey] != "") || (pts.Annotations[cloudPakRatioKey] != "") || (pts.Annotations[cloudPakIdKey] != "") {
+		t.Errorf("License annotations should not be set when %s is set: '%s', '%s', '%s'", excludeLicenseAnnotationsKey,
+			pts.Annotations[cloudPakNameKey], pts.Annotations[cloudPakRatioKey], pts.Annotations[cloudPakIdKey])
+	}
 
-	// Test that annotations are skipped, even where they where previously set
+	// Test that annotations are skipped, even where they were previously set
 	pts.Annotations[productIDKey] = editionProductID[webspherelibertyv1.LicenseEditionBase]
 	pts.Annotations[productChargedContainersKey] = "app"
 	pts.Annotations[productMetricKey] = "PROCESSOR_VALUE_UNIT"

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -366,6 +366,31 @@ func TestCustomizeLicenseAnnotations(t *testing.T) {
 
 	}
 
+	// Test where annotations should be skipped
+	s := licenseTestData{edition: webspherelibertyv1.LicenseEditionND, pes: webspherelibertyv1.LicenseEntitlementWSHE}
+	t.Logf("Testing %#v\n", s)
+	spec := webspherelibertyv1.WebSphereLibertyApplicationSpec{}
+	spec.License.Metric = s.metric
+	spec.License.ProductEntitlementSource = s.pes
+	spec.License.Edition = s.edition
+	app := createWebSphereLibertyApp("myapp", "myns", spec)
+	app.ObjectMeta.Annotations = map[string]string{excludeLicenseAnnotationsKey: "true"}
+	pts := &corev1.PodTemplateSpec{}
+	pts.Annotations = make(map[string]string)
+	CustomizeLicenseAnnotations(pts, app)
+	if (pts.Annotations[productIDKey] != "") || (pts.Annotations[productChargedContainersKey] != "") || (pts.Annotations[productMetricKey] != "") || (pts.Annotations[productNameKey] != "") {
+		t.Errorf("License annotations should not be set when %s is set: '%s', '%s', '%s', '%s'", excludeLicenseAnnotationsKey,
+			pts.Annotations[productIDKey], pts.Annotations[productChargedContainersKey], pts.Annotations[productMetricKey], pts.Annotations[productNameKey])
+	}
+
+	// Test that annotations are skipped, even where they where previously set
+	pts.Annotations[productIDKey] = editionProductID[webspherelibertyv1.LicenseEditionBase]
+	CustomizeLicenseAnnotations(pts, app)
+	if (pts.Annotations[productIDKey] != "") || (pts.Annotations[productChargedContainersKey] != "") || (pts.Annotations[productMetricKey] != "") || (pts.Annotations[productNameKey] != "") {
+		t.Errorf("License annotations should not be set when %s is set: '%s', '%s', '%s', '%s'", excludeLicenseAnnotationsKey,
+			pts.Annotations[productIDKey], pts.Annotations[productChargedContainersKey], pts.Annotations[productMetricKey], pts.Annotations[productNameKey])
+	}
+
 }
 
 func checkRatio(ratio string, edition webspherelibertyv1.LicenseEdition) bool {


### PR DESCRIPTION
Possibly should also skip cloud pak annotations?

Deals with issue #597 