### PR TITLE
Add a Failed condition to WebSphereLibertyDump

### DIFF
--- a/api/v1/operations.go
+++ b/api/v1/operations.go
@@ -67,6 +67,8 @@ const (
 	OperationStatusConditionTypeEnabled OperationStatusConditionType = "Enabled"
 	// OperationStatusConditionTypeStarted indicates whether operation has been started
 	OperationStatusConditionTypeStarted OperationStatusConditionType = "Started"
+	// OperationStatusConditionTypeFailed indicates whether operation has failed
+	OperationStatusConditionTypeFailed OperationStatusConditionType = "Failed"
 	// OperationStatusConditionTypeCompleted indicates whether operation has been completed
 	OperationStatusConditionTypeCompleted OperationStatusConditionType = "Completed"
 	// OperationStatusConditionTypeFailed indicates whether operation has failed

--- a/api/v1/webspherelibertydump_types.go
+++ b/api/v1/webspherelibertydump_types.go
@@ -53,6 +53,7 @@ const (
 // Defines the observed state of WebSphereLibertyDump
 type WebSphereLibertyDumpStatus struct {
 	// +listType=atomic
+	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="Status Conditions",xDescriptors="urn:alm:descriptor:io.kubernetes.conditions"
 	Conditions []OperationStatusCondition `json:"conditions,omitempty"`
 	Versions   DumpStatusVersions         `json:"versions,omitempty"`
 	// Location of the generated dump file

--- a/api/v1/webspherelibertytrace_types.go
+++ b/api/v1/webspherelibertytrace_types.go
@@ -58,6 +58,7 @@ type LicenseSimple struct {
 // Defines the observed state of WebSphereLibertyTrace operation
 type WebSphereLibertyTraceStatus struct {
 	// +listType=atomic
+	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="Status Conditions",xDescriptors="urn:alm:descriptor:io.kubernetes.conditions"
 	Conditions       []OperationStatusCondition `json:"conditions,omitempty"`
 	OperatedResource OperatedResource           `json:"operatedResource,omitempty"`
 	Versions         TraceStatusVersions        `json:"versions,omitempty"`

--- a/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
@@ -67,7 +67,7 @@ metadata:
     capabilities: Auto Pilot
     categories: Application Runtime
     containerImage: icr.io/cpopen/websphere-liberty-operator:daily
-    createdAt: "2026-06-15T17:10:53Z"
+    createdAt: "2026-06-24T13:41:18Z"
     description: Deploy and manage containerized Liberty applications
     features.operators.openshift.io/disconnected: "true"
     olm.skipRange: '>=1.0.0 <1.6.2'
@@ -812,6 +812,10 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:checkbox
       statusDescriptors:
+      - displayName: Status Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
       - description: Location of the generated dump file
         displayName: Dump File Path
         path: dumpFile
@@ -849,6 +853,10 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:checkbox
       statusDescriptors:
+      - displayName: Status Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
       - description: Location of the trace log directory
         displayName: Log Directory
         path: logDirectory

--- a/config/manifests/bases/ibm-websphere-liberty.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-websphere-liberty.clusterserviceversion.yaml
@@ -672,6 +672,10 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:checkbox
       statusDescriptors:
+      - displayName: Status Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
       - description: Location of the generated dump file
         displayName: Dump File Path
         path: dumpFile
@@ -709,6 +713,10 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:checkbox
       statusDescriptors:
+      - displayName: Status Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
       - description: Location of the trace log directory
         displayName: Log Directory
         path: logDirectory

--- a/internal/controller/webspherelibertydump_controller.go
+++ b/internal/controller/webspherelibertydump_controller.go
@@ -95,8 +95,14 @@ func (r *ReconcileWebSphereLibertyDump) Reconcile(ctx context.Context, request c
 		reqLogger.Error(err, message)
 		r.Recorder.Event(instance, "Warning", "ProcessingError", message)
 		c := webspherelibertyv1.OperationStatusCondition{
-			Type:    webspherelibertyv1.OperationStatusConditionTypeStarted,
-			Status:  corev1.ConditionFalse,
+			Type:   webspherelibertyv1.OperationStatusConditionTypeStarted,
+			Status: corev1.ConditionFalse,
+		}
+		instance.Status.Conditions = webspherelibertyv1.SetOperationCondtion(instance.Status.Conditions, c)
+		// Additionally, set the condition to Failed to update the UI
+		f := webspherelibertyv1.OperationStatusCondition{
+			Type:    webspherelibertyv1.OperationStatusConditionTypeFailed,
+			Status:  corev1.ConditionTrue,
 			Reason:  "Error",
 			Message: "Failed to find a pod or pod is not in running state",
 		}
@@ -122,22 +128,32 @@ func (r *ReconcileWebSphereLibertyDump) Reconcile(ctx context.Context, request c
 		Type:   webspherelibertyv1.OperationStatusConditionTypeStarted,
 		Status: corev1.ConditionTrue,
 	}
-
 	instance.Status.Conditions = webspherelibertyv1.SetOperationCondtion(instance.Status.Conditions, c)
+	f := webspherelibertyv1.OperationStatusCondition{
+		Type:   webspherelibertyv1.OperationStatusConditionTypeFailed,
+		Status: corev1.ConditionFalse,
+	}
+	instance.Status.Conditions = webspherelibertyv1.SetOperationCondtion(instance.Status.Conditions, f)
 	r.Client.Status().Update(context.TODO(), instance)
 
 	_, err = utils.ExecuteCommandInContainer(r.RestConfig, pod.Name, pod.Namespace, "app", []string{"/bin/sh", "-c", dumpCmd})
 	if err != nil {
 		//handle error
-		reqLogger.Error(err, "Execute dump cmd failed ", "cmd", dumpCmd)
+		reqLogger.Error(err, "Execute dump cmd failed", "cmd", dumpCmd)
 		r.Recorder.Event(instance, "Warning", "ProcessingError", err.Error())
 		c = webspherelibertyv1.OperationStatusCondition{
-			Type:    webspherelibertyv1.OperationStatusConditionTypeCompleted,
-			Status:  corev1.ConditionFalse,
+			Type:   webspherelibertyv1.OperationStatusConditionTypeCompleted,
+			Status: corev1.ConditionFalse,
+		}
+		instance.Status.Conditions = webspherelibertyv1.SetOperationCondtion(instance.Status.Conditions, c)
+		// Additionally, set the condition to Failed to update the UI
+		f = webspherelibertyv1.OperationStatusCondition{
+			Type:    webspherelibertyv1.OperationStatusConditionTypeFailed,
+			Status:  corev1.ConditionTrue,
 			Reason:  "Error",
 			Message: err.Error(),
 		}
-		instance.Status.Conditions = webspherelibertyv1.SetOperationCondtion(instance.Status.Conditions, c)
+		instance.Status.Conditions = webspherelibertyv1.SetOperationCondtion(instance.Status.Conditions, f)
 		instance.Status.ObservedGeneration = instance.GetObjectMeta().GetGeneration()
 		instance.Status.Versions.Reconciled = utils.OperandVersion
 		r.Client.Status().Update(context.TODO(), instance)
@@ -149,8 +165,12 @@ func (r *ReconcileWebSphereLibertyDump) Reconcile(ctx context.Context, request c
 		Type:   webspherelibertyv1.OperationStatusConditionTypeCompleted,
 		Status: corev1.ConditionTrue,
 	}
-
 	instance.Status.Conditions = webspherelibertyv1.SetOperationCondtion(instance.Status.Conditions, c)
+	f = webspherelibertyv1.OperationStatusCondition{
+		Type:   webspherelibertyv1.OperationStatusConditionTypeFailed,
+		Status: corev1.ConditionFalse,
+	}
+	instance.Status.Conditions = webspherelibertyv1.SetOperationCondtion(instance.Status.Conditions, f)
 	instance.Status.DumpFile = dumpFileName
 	instance.Status.ObservedGeneration = instance.GetObjectMeta().GetGeneration()
 	instance.Status.Versions.Reconciled = utils.OperandVersion


### PR DESCRIPTION
Related issue: https://github.com/OpenLiberty/open-liberty-operator/issues/538

Conditions are only displayed in the OpenShift UI when set to True.
This causes errors to not be displayed in the UI when `Completed = False` errors.
By creating a new condition `Failed = True` taking the error from above, it will properly update the UI to inform the WLO user that the WebSphereLibertyDump failed. 

