### PR TITLE
Update version to 1.3.2, update RCO module + misc fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 ARG USER_ID=65532
 ARG GROUP_ID=65532
 
-ARG VERSION_LABEL=1.3.1
+ARG VERSION_LABEL=1.3.2
 ARG RELEASE_LABEL=XX
 ARG VCS_REF=0123456789012345678901234567890123456789
 ARG VCS_URL="https://github.com/WASdev/websphere-liberty-operator"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.3.1
+VERSION ?= 1.3.2
 OPERATOR_SDK_RELEASE_VERSION ?= v1.27.0
 
 # CHANNELS define the bundle channels used in the bundle.

--- a/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
@@ -33,8 +33,7 @@ metadata:
           },
           "spec": {
             "include": [
-              "thread",
-              "heap"
+              "thread"
             ],
             "license": {
               "accept": false
@@ -62,7 +61,7 @@ metadata:
     capabilities: Auto Pilot
     categories: Application Runtime
     containerImage: icr.io/cpopen/websphere-liberty-operator:daily
-    createdAt: "2024-05-01T21:25:26Z"
+    createdAt: "2024-05-01T21:30:53Z"
     description: Deploy and manage containerized Liberty applications
     olm.skipRange: '>=1.0.0 <1.3.2'
     operators.openshift.io/infrastructure-features: '["disconnected"]'

--- a/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
@@ -62,9 +62,9 @@ metadata:
     capabilities: Auto Pilot
     categories: Application Runtime
     containerImage: icr.io/cpopen/websphere-liberty-operator:daily
-    createdAt: "2024-05-01T17:43:30Z"
+    createdAt: "2024-05-01T21:25:26Z"
     description: Deploy and manage containerized Liberty applications
-    olm.skipRange: '>=1.0.0 <1.3.1'
+    olm.skipRange: '>=1.0.0 <1.3.2'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.27.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -75,7 +75,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: ibm-websphere-liberty.v1.3.1
+  name: ibm-websphere-liberty.v1.3.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1201,4 +1201,4 @@ spec:
     name: liberty-sample-app
   - image: icr.io/cpopen/websphere-liberty-operator:daily
     name: websphere-liberty-operator
-  version: 1.3.1
+  version: 1.3.2

--- a/catalog.Dockerfile
+++ b/catalog.Dockerfile
@@ -2,7 +2,7 @@ FROM registry.redhat.io/openshift4/ose-operator-registry:v4.14 AS builder
 FROM registry.redhat.io/ubi8/ubi-minimal
 
 # Add label for location of Declarative Config root directory & required OpenShift labels
-ARG VERSION_LABEL=1.3.1
+ARG VERSION_LABEL=1.3.2
 ARG RELEASE_LABEL=XX
 ARG VCS_REF=0123456789012345678901234567890123456789
 ARG VCS_URL="https://github.com/WASdev/websphere-liberty-operator"

--- a/config/manifests/bases/ibm-websphere-liberty.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-websphere-liberty.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Application Runtime
     createdAt: "2021-11-25T14:00:00Z"
     description: Deploy and manage containerized Liberty applications
-    olm.skipRange: '>=1.0.0 <1.3.1'
+    olm.skipRange: '>=1.0.0 <1.3.2'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     repository: https://github.com/WASdev/websphere-liberty-operator
     support: IBM

--- a/config/samples/liberty.websphere.ibm.com_v1_webspherelibertydumps.yaml
+++ b/config/samples/liberty.websphere.ibm.com_v1_webspherelibertydumps.yaml
@@ -8,4 +8,3 @@ spec:
   podName: Specify_Pod_Name_Here
   include:
   - thread
-  - heap

--- a/controllers/webspherelibertyapplication_controller.go
+++ b/controllers/webspherelibertyapplication_controller.go
@@ -258,21 +258,24 @@ func (r *ReconcileWebSphereLiberty) Reconcile(ctx context.Context, request ctrl.
 		}
 	}
 
-	if oputils.GetServiceAccountName(instance) == "" {
-		serviceAccount := &corev1.ServiceAccount{ObjectMeta: defaultMeta}
-		err = r.CreateOrUpdate(serviceAccount, instance, func() error {
-			return oputils.CustomizeServiceAccount(serviceAccount, instance, r.GetClient())
-		})
-		if err != nil {
-			reqLogger.Error(err, "Failed to reconcile ServiceAccount")
-			return r.ManageError(err, common.StatusConditionTypeReconciled, instance)
-		}
-	} else {
-		serviceAccount := &corev1.ServiceAccount{ObjectMeta: defaultMeta}
-		err = r.DeleteResource(serviceAccount)
-		if err != nil {
-			reqLogger.Error(err, "Failed to delete ServiceAccount")
-			return r.ManageError(err, common.StatusConditionTypeReconciled, instance)
+	serviceAccountName := oputils.GetServiceAccountName(instance)
+	if serviceAccountName != defaultMeta.Name {
+		if serviceAccountName == "" {
+			serviceAccount := &corev1.ServiceAccount{ObjectMeta: defaultMeta}
+			err = r.CreateOrUpdate(serviceAccount, instance, func() error {
+				return oputils.CustomizeServiceAccount(serviceAccount, instance, r.GetClient())
+			})
+			if err != nil {
+				reqLogger.Error(err, "Failed to reconcile ServiceAccount")
+				return r.ManageError(err, common.StatusConditionTypeReconciled, instance)
+			}
+		} else {
+			serviceAccount := &corev1.ServiceAccount{ObjectMeta: defaultMeta}
+			err = r.DeleteResource(serviceAccount)
+			if err != nil {
+				reqLogger.Error(err, "Failed to delete ServiceAccount")
+				return r.ManageError(err, common.StatusConditionTypeReconciled, instance)
+			}
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/WASdev/websphere-liberty-operator
 go 1.21
 
 require (
-	github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20240418093352-75f8d52a0afa
+	github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20240501200723-fc6ae9079c88
 	github.com/cert-manager/cert-manager v1.11.5
 	github.com/go-logr/logr v1.2.4
 	github.com/openshift/api v0.0.0-20230928134114-673ed0cfc7f1

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20240418093352-75f8d52a0afa h1:1EdnXjNuPJkoNIYdD8ZDQPmuPuIeBXpyWLHIVAEWXlg=
-github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20240418093352-75f8d52a0afa/go.mod h1:QI32wLzUBxvvisPG+p1XeogxeUhk64Vc/U0lx7rxx5M=
+github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20240501200723-fc6ae9079c88 h1:v+D27NsIOia3fLxx9Z8n0WEvHJZsASrnsygOUT60z9g=
+github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20240501200723-fc6ae9079c88/go.mod h1:QI32wLzUBxvvisPG+p1XeogxeUhk64Vc/U0lx7rxx5M=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -50,7 +50,7 @@ var log = logf.Log.WithName("websphereliberty_utils")
 // Constant Values
 const serviceabilityMountPath = "/serviceability"
 const ssoEnvVarPrefix = "SEC_SSO_"
-const OperandVersion = "1.3.1"
+const OperandVersion = "1.3.2"
 const ltpaKeysMountPath = "/config/managedLTPA"
 const ltpaServerXMLOverridesMountPath = "/config/configDropins/overrides/"
 const LTPAServerXMLSuffix = "-managed-ltpa-server-xml"


### PR DESCRIPTION
- Update Operator version to 1.3.2 (https://github.com/WASdev/websphere-liberty-operator/issues/627)
- Update RCO module
- Port fixes for the following:
   - Prevent deleting or managing user-specified serviceaccount (https://github.com/OpenLiberty/open-liberty-operator/issues/433) - OLO PR is https://github.com/OpenLiberty/open-liberty-operator/pull/441/files
   - Change default sample Dump includes (https://github.com/WASdev/websphere-liberty-operator/issues/630). OLO PR is https://github.com/OpenLiberty/open-liberty-operator/pull/552/files
