### PR TITLE
Add support for CP4Apps Advanced entitlement

### DIFF
--- a/api/v1/webspherelibertyapplication_types.go
+++ b/api/v1/webspherelibertyapplication_types.go
@@ -34,6 +34,7 @@ import (
 // Defines the desired state of WebSphereLibertyApplication.
 type WebSphereLibertyApplicationSpec struct {
 
+	// The license must be reviewed and accepted before the application can be deployed.
 	// +operator-sdk:csv:customresourcedefinitions:order=1,type=spec,displayName="License",xDescriptors="urn:alm:descriptor:com.tectonic.ui:text"
 	License License `json:"license"`
 
@@ -172,7 +173,6 @@ type WebSphereLibertyApplicationSpec struct {
 	DisableServiceLinks *bool `json:"disableServiceLinks,omitempty"`
 }
 
-// License information is required.
 type License struct {
 	// Product edition. Defaults to IBM WebSphere Application Server. Other options: IBM WebSphere Application Server Liberty Core, IBM WebSphere Application Server Network Deployment
 	// +operator-sdk:csv:customresourcedefinitions:order=100,type=spec,displayName="Edition"

--- a/api/v1/webspherelibertyapplication_types.go
+++ b/api/v1/webspherelibertyapplication_types.go
@@ -218,18 +218,22 @@ const (
 )
 
 // Defines the possible values for product entitlement source
-// +kubebuilder:validation:Enum=Standalone;IBM Cloud Pak for Applications;IBM WebSphere Application Server Family Edition;IBM WebSphere Hybrid Edition
+// +kubebuilder:validation:Enum=Standalone;IBM Cloud Pak for Applications Advanced;IBM Cloud Pak for Applications Standard;IBM WebSphere Hybrid Edition;IBM WebSphere Application Server Family Edition;IBM Cloud Pak for Applications
 type LicenseEntitlement string
 
 const (
 	// Entitlement source Standalone
 	LicenseEntitlementStandalone LicenseEntitlement = "Standalone"
-	// Entitlement source IBM Cloud Pak for Applications
-	LicenseEntitlementCP4Apps LicenseEntitlement = "IBM Cloud Pak for Applications"
-	// Entitlement source IBM WebSphere Application Server Family Edition
-	LicenseEntitlementFamilyEdition LicenseEntitlement = "IBM WebSphere Application Server Family Edition"
+	// Entitlement source IBM Cloud Pak for Applications Advanced
+	LicenseEntitlementCP4AppsAdvanced LicenseEntitlement = "IBM Cloud Pak for Applications Advanced"
+	// Entitlement source IBM Cloud Pak for Applications Standard
+	LicenseEntitlementCP4AppsStandard LicenseEntitlement = "IBM Cloud Pak for Applications Standard"
 	// Entitlement source IBM WebSphere Hybrid Edition
 	LicenseEntitlementWSHE LicenseEntitlement = "IBM WebSphere Hybrid Edition"
+	// Entitlement source IBM WebSphere Application Server Family Edition
+	LicenseEntitlementFamilyEdition LicenseEntitlement = "IBM WebSphere Application Server Family Edition"
+	// Entitlement source IBM Cloud Pak for Applications
+	LicenseEntitlementCP4Apps LicenseEntitlement = "IBM Cloud Pak for Applications"
 )
 
 // Defines the topology spread constraints

--- a/api/v1/webspherelibertyapplication_types.go
+++ b/api/v1/webspherelibertyapplication_types.go
@@ -178,7 +178,7 @@ type License struct {
 	// +operator-sdk:csv:customresourcedefinitions:order=100,type=spec,displayName="Edition"
 	Edition LicenseEdition `json:"edition,omitempty"`
 
-	// Entitlement source for the product. Defaults to Standalone. Other options: IBM Cloud Pak for Applications, IBM WebSphere Application Server Family Edition, IBM WebSphere Hybrid Edition
+	// Entitlement source for the product. Defaults to Standalone. Other options: IBM Cloud Pak for Applications Advanced, IBM Cloud Pak for Applications Standard, IBM WebSphere Hybrid Edition, IBM WebSphere Application Server Family Edition
 	// +operator-sdk:csv:customresourcedefinitions:order=101,type=spec,displayName="Product Entitlement Source"
 	ProductEntitlementSource LicenseEntitlement `json:"productEntitlementSource,omitempty"`
 

--- a/api/v1/webspherelibertyapplication_types.go
+++ b/api/v1/webspherelibertyapplication_types.go
@@ -178,7 +178,7 @@ type License struct {
 	// +operator-sdk:csv:customresourcedefinitions:order=100,type=spec,displayName="Edition"
 	Edition LicenseEdition `json:"edition,omitempty"`
 
-	// Entitlement source for the product. Defaults to Standalone. Other options: IBM Cloud Pak for Applications Advanced, IBM Cloud Pak for Applications Standard, IBM WebSphere Hybrid Edition, IBM WebSphere Application Server Family Edition
+	// Entitlement source for the product. Defaults to Standalone. Other options: IBM Cloud Pak for Applications Advanced, IBM Cloud Pak for Applications Standard, IBM WebSphere Hybrid Edition, IBM WebSphere Application Server Family Edition. Option IBM Cloud Pak for Applications is deprecated. Use option IBM Cloud Pak for Applications Standard instead.
 	// +operator-sdk:csv:customresourcedefinitions:order=101,type=spec,displayName="Product Entitlement Source"
 	ProductEntitlementSource LicenseEntitlement `json:"productEntitlementSource,omitempty"`
 

--- a/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
@@ -61,7 +61,7 @@ metadata:
     capabilities: Auto Pilot
     categories: Application Runtime
     containerImage: icr.io/cpopen/websphere-liberty-operator:daily
-    createdAt: "2024-07-12T19:53:58Z"
+    createdAt: "2024-07-12T20:01:15Z"
     description: Deploy and manage containerized Liberty applications
     olm.skipRange: '>=1.0.0 <1.3.3'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
@@ -561,8 +561,9 @@ spec:
         displayName: Edition
         path: license.edition
       - description: 'Entitlement source for the product. Defaults to Standalone.
-          Other options: IBM Cloud Pak for Applications, IBM WebSphere Application
-          Server Family Edition, IBM WebSphere Hybrid Edition'
+          Other options: IBM Cloud Pak for Applications Advanced, IBM Cloud Pak for
+          Applications Standard, IBM WebSphere Hybrid Edition, IBM WebSphere Application
+          Server Family Edition'
         displayName: Product Entitlement Source
         path: license.productEntitlementSource
       - description: Deprecated. Charge metric code is now automatically determined

--- a/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
@@ -61,7 +61,7 @@ metadata:
     capabilities: Auto Pilot
     categories: Application Runtime
     containerImage: icr.io/cpopen/websphere-liberty-operator:daily
-    createdAt: "2024-07-12T20:50:05Z"
+    createdAt: "2024-07-15T15:45:26Z"
     description: Deploy and manage containerized Liberty applications
     olm.skipRange: '>=1.0.0 <1.3.3'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
@@ -565,7 +565,8 @@ spec:
       - description: 'Entitlement source for the product. Defaults to Standalone.
           Other options: IBM Cloud Pak for Applications Advanced, IBM Cloud Pak for
           Applications Standard, IBM WebSphere Hybrid Edition, IBM WebSphere Application
-          Server Family Edition'
+          Server Family Edition. Option IBM Cloud Pak for Applications is deprecated.
+          Use option IBM Cloud Pak for Applications Standard instead.'
         displayName: Product Entitlement Source
         path: license.productEntitlementSource
       - description: Deprecated. Charge metric code is now automatically determined

--- a/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
@@ -61,7 +61,7 @@ metadata:
     capabilities: Auto Pilot
     categories: Application Runtime
     containerImage: icr.io/cpopen/websphere-liberty-operator:daily
-    createdAt: "2024-07-12T20:01:15Z"
+    createdAt: "2024-07-12T20:50:05Z"
     description: Deploy and manage containerized Liberty applications
     olm.skipRange: '>=1.0.0 <1.3.3'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
@@ -124,7 +124,9 @@ spec:
         path: autoscaling.maxReplicas
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
-      - displayName: License
+      - description: The license must be reviewed and accepted before the application
+          can be deployed.
+        displayName: License
         path: license
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text

--- a/bundle/manifests/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
+++ b/bundle/manifests/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
@@ -2438,7 +2438,8 @@ spec:
                 - name
                 x-kubernetes-list-type: map
               license:
-                description: License information is required.
+                description: The license must be reviewed and accepted before the
+                  application can be deployed.
                 properties:
                   accept:
                     description: |-

--- a/bundle/manifests/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
+++ b/bundle/manifests/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
@@ -2469,7 +2469,9 @@ spec:
                     description: 'Entitlement source for the product. Defaults to
                       Standalone. Other options: IBM Cloud Pak for Applications Advanced,
                       IBM Cloud Pak for Applications Standard, IBM WebSphere Hybrid
-                      Edition, IBM WebSphere Application Server Family Edition'
+                      Edition, IBM WebSphere Application Server Family Edition. Option
+                      IBM Cloud Pak for Applications is deprecated. Use option IBM
+                      Cloud Pak for Applications Standard instead.'
                     enum:
                     - Standalone
                     - IBM Cloud Pak for Applications Advanced

--- a/bundle/manifests/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
+++ b/bundle/manifests/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
@@ -2466,14 +2466,16 @@ spec:
                     type: string
                   productEntitlementSource:
                     description: 'Entitlement source for the product. Defaults to
-                      Standalone. Other options: IBM Cloud Pak for Applications, IBM
-                      WebSphere Application Server Family Edition, IBM WebSphere Hybrid
-                      Edition'
+                      Standalone. Other options: IBM Cloud Pak for Applications Advanced,
+                      IBM Cloud Pak for Applications Standard, IBM WebSphere Hybrid
+                      Edition, IBM WebSphere Application Server Family Edition'
                     enum:
                     - Standalone
-                    - IBM Cloud Pak for Applications
-                    - IBM WebSphere Application Server Family Edition
+                    - IBM Cloud Pak for Applications Advanced
+                    - IBM Cloud Pak for Applications Standard
                     - IBM WebSphere Hybrid Edition
+                    - IBM WebSphere Application Server Family Edition
+                    - IBM Cloud Pak for Applications
                     type: string
                 required:
                 - accept

--- a/config/crd/bases/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
+++ b/config/crd/bases/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
@@ -2462,14 +2462,16 @@ spec:
                     type: string
                   productEntitlementSource:
                     description: 'Entitlement source for the product. Defaults to
-                      Standalone. Other options: IBM Cloud Pak for Applications, IBM
-                      WebSphere Application Server Family Edition, IBM WebSphere Hybrid
-                      Edition'
+                      Standalone. Other options: IBM Cloud Pak for Applications Advanced,
+                      IBM Cloud Pak for Applications Standard, IBM WebSphere Hybrid
+                      Edition, IBM WebSphere Application Server Family Edition'
                     enum:
                     - Standalone
-                    - IBM Cloud Pak for Applications
-                    - IBM WebSphere Application Server Family Edition
+                    - IBM Cloud Pak for Applications Advanced
+                    - IBM Cloud Pak for Applications Standard
                     - IBM WebSphere Hybrid Edition
+                    - IBM WebSphere Application Server Family Edition
+                    - IBM Cloud Pak for Applications
                     type: string
                 required:
                 - accept

--- a/config/crd/bases/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
+++ b/config/crd/bases/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
@@ -2434,7 +2434,8 @@ spec:
                 - name
                 x-kubernetes-list-type: map
               license:
-                description: License information is required.
+                description: The license must be reviewed and accepted before the
+                  application can be deployed.
                 properties:
                   accept:
                     description: |-

--- a/config/crd/bases/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
+++ b/config/crd/bases/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
@@ -2465,7 +2465,9 @@ spec:
                     description: 'Entitlement source for the product. Defaults to
                       Standalone. Other options: IBM Cloud Pak for Applications Advanced,
                       IBM Cloud Pak for Applications Standard, IBM WebSphere Hybrid
-                      Edition, IBM WebSphere Application Server Family Edition'
+                      Edition, IBM WebSphere Application Server Family Edition. Option
+                      IBM Cloud Pak for Applications is deprecated. Use option IBM
+                      Cloud Pak for Applications Standard instead.'
                     enum:
                     - Standalone
                     - IBM Cloud Pak for Applications Advanced

--- a/config/manifests/bases/ibm-websphere-liberty.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-websphere-liberty.clusterserviceversion.yaml
@@ -507,7 +507,8 @@ spec:
       - description: 'Entitlement source for the product. Defaults to Standalone.
           Other options: IBM Cloud Pak for Applications Advanced, IBM Cloud Pak for
           Applications Standard, IBM WebSphere Hybrid Edition, IBM WebSphere Application
-          Server Family Edition'
+          Server Family Edition. Option IBM Cloud Pak for Applications is deprecated.
+          Use option IBM Cloud Pak for Applications Standard instead.'
         displayName: Product Entitlement Source
         path: license.productEntitlementSource
       - description: Deprecated. Charge metric code is now automatically determined

--- a/config/manifests/bases/ibm-websphere-liberty.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-websphere-liberty.clusterserviceversion.yaml
@@ -503,8 +503,9 @@ spec:
         displayName: Edition
         path: license.edition
       - description: 'Entitlement source for the product. Defaults to Standalone.
-          Other options: IBM Cloud Pak for Applications, IBM WebSphere Application
-          Server Family Edition, IBM WebSphere Hybrid Edition'
+          Other options: IBM Cloud Pak for Applications Advanced, IBM Cloud Pak for
+          Applications Standard, IBM WebSphere Hybrid Edition, IBM WebSphere Application
+          Server Family Edition'
         displayName: Product Entitlement Source
         path: license.productEntitlementSource
       - description: Deprecated. Charge metric code is now automatically determined

--- a/config/manifests/bases/ibm-websphere-liberty.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-websphere-liberty.clusterserviceversion.yaml
@@ -66,7 +66,9 @@ spec:
         path: autoscaling.maxReplicas
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
-      - displayName: License
+      - description: The license must be reviewed and accepted before the application
+          can be deployed.
+        displayName: License
         path: license
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text

--- a/internal/deploy/kubectl/websphereliberty-app-crd.yaml
+++ b/internal/deploy/kubectl/websphereliberty-app-crd.yaml
@@ -2437,7 +2437,8 @@ spec:
                 - name
                 x-kubernetes-list-type: map
               license:
-                description: License information is required.
+                description: The license must be reviewed and accepted before the
+                  application can be deployed.
                 properties:
                   accept:
                     description: |-

--- a/internal/deploy/kubectl/websphereliberty-app-crd.yaml
+++ b/internal/deploy/kubectl/websphereliberty-app-crd.yaml
@@ -2468,7 +2468,9 @@ spec:
                     description: 'Entitlement source for the product. Defaults to
                       Standalone. Other options: IBM Cloud Pak for Applications Advanced,
                       IBM Cloud Pak for Applications Standard, IBM WebSphere Hybrid
-                      Edition, IBM WebSphere Application Server Family Edition'
+                      Edition, IBM WebSphere Application Server Family Edition. Option
+                      IBM Cloud Pak for Applications is deprecated. Use option IBM
+                      Cloud Pak for Applications Standard instead.'
                     enum:
                     - Standalone
                     - IBM Cloud Pak for Applications Advanced

--- a/internal/deploy/kubectl/websphereliberty-app-crd.yaml
+++ b/internal/deploy/kubectl/websphereliberty-app-crd.yaml
@@ -2465,14 +2465,16 @@ spec:
                     type: string
                   productEntitlementSource:
                     description: 'Entitlement source for the product. Defaults to
-                      Standalone. Other options: IBM Cloud Pak for Applications, IBM
-                      WebSphere Application Server Family Edition, IBM WebSphere Hybrid
-                      Edition'
+                      Standalone. Other options: IBM Cloud Pak for Applications Advanced,
+                      IBM Cloud Pak for Applications Standard, IBM WebSphere Hybrid
+                      Edition, IBM WebSphere Application Server Family Edition'
                     enum:
                     - Standalone
-                    - IBM Cloud Pak for Applications
-                    - IBM WebSphere Application Server Family Edition
+                    - IBM Cloud Pak for Applications Advanced
+                    - IBM Cloud Pak for Applications Standard
                     - IBM WebSphere Hybrid Edition
+                    - IBM WebSphere Application Server Family Edition
+                    - IBM Cloud Pak for Applications
                     type: string
                 required:
                 - accept

--- a/internal/deploy/kustomize/daily/base/websphere-liberty-crd.yaml
+++ b/internal/deploy/kustomize/daily/base/websphere-liberty-crd.yaml
@@ -2437,7 +2437,8 @@ spec:
                 - name
                 x-kubernetes-list-type: map
               license:
-                description: License information is required.
+                description: The license must be reviewed and accepted before the
+                  application can be deployed.
                 properties:
                   accept:
                     description: |-

--- a/internal/deploy/kustomize/daily/base/websphere-liberty-crd.yaml
+++ b/internal/deploy/kustomize/daily/base/websphere-liberty-crd.yaml
@@ -2468,7 +2468,9 @@ spec:
                     description: 'Entitlement source for the product. Defaults to
                       Standalone. Other options: IBM Cloud Pak for Applications Advanced,
                       IBM Cloud Pak for Applications Standard, IBM WebSphere Hybrid
-                      Edition, IBM WebSphere Application Server Family Edition'
+                      Edition, IBM WebSphere Application Server Family Edition. Option
+                      IBM Cloud Pak for Applications is deprecated. Use option IBM
+                      Cloud Pak for Applications Standard instead.'
                     enum:
                     - Standalone
                     - IBM Cloud Pak for Applications Advanced

--- a/internal/deploy/kustomize/daily/base/websphere-liberty-crd.yaml
+++ b/internal/deploy/kustomize/daily/base/websphere-liberty-crd.yaml
@@ -2465,14 +2465,16 @@ spec:
                     type: string
                   productEntitlementSource:
                     description: 'Entitlement source for the product. Defaults to
-                      Standalone. Other options: IBM Cloud Pak for Applications, IBM
-                      WebSphere Application Server Family Edition, IBM WebSphere Hybrid
-                      Edition'
+                      Standalone. Other options: IBM Cloud Pak for Applications Advanced,
+                      IBM Cloud Pak for Applications Standard, IBM WebSphere Hybrid
+                      Edition, IBM WebSphere Application Server Family Edition'
                     enum:
                     - Standalone
-                    - IBM Cloud Pak for Applications
-                    - IBM WebSphere Application Server Family Edition
+                    - IBM Cloud Pak for Applications Advanced
+                    - IBM Cloud Pak for Applications Standard
                     - IBM WebSphere Hybrid Edition
+                    - IBM WebSphere Application Server Family Edition
+                    - IBM Cloud Pak for Applications
                     type: string
                 required:
                 - accept

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -74,9 +74,11 @@ var editionProductID = map[wlv1.LicenseEdition]string{
 }
 
 var entitlementCloudPakID = map[wlv1.LicenseEntitlement]string{
-	wlv1.LicenseEntitlementCP4Apps:       "4df52d2cdc374ba09f631a650ad2b5bf",
-	wlv1.LicenseEntitlementFamilyEdition: "be8ae84b3dd04d81b90af0d846849182",
-	wlv1.LicenseEntitlementWSHE:          "6358611af04743f99f42dadcd6e39d52",
+	wlv1.LicenseEntitlementCP4AppsAdvanced: "217562c7767641d982cc6df6bcb5cb87",
+	wlv1.LicenseEntitlementCP4AppsStandard: "4df52d2cdc374ba09f631a650ad2b5bf",
+	wlv1.LicenseEntitlementWSHE:            "6358611af04743f99f42dadcd6e39d52",
+	wlv1.LicenseEntitlementFamilyEdition:   "be8ae84b3dd04d81b90af0d846849182",
+	wlv1.LicenseEntitlementCP4Apps:         "4df52d2cdc374ba09f631a650ad2b5bf",
 }
 
 // Validate if the WebSpherLibertyApplication is valid
@@ -218,7 +220,7 @@ func CustomizeLicenseAnnotations(pts *corev1.PodTemplateSpec, la *wlv1.WebSphere
 	entitlement := la.Spec.License.ProductEntitlementSource
 
 	metricValue := "PROCESSOR_VALUE_UNIT"
-	if entitlement == wlv1.LicenseEntitlementWSHE || entitlement == wlv1.LicenseEntitlementCP4Apps {
+	if entitlement == wlv1.LicenseEntitlementCP4AppsAdvanced || entitlement == wlv1.LicenseEntitlementCP4AppsStandard || entitlement == wlv1.LicenseEntitlementWSHE || entitlement == wlv1.LicenseEntitlementCP4Apps {
 		metricValue = "VIRTUAL_PROCESSOR_CORE"
 	}
 	pts.Annotations[productMetricKey] = metricValue
@@ -226,14 +228,27 @@ func CustomizeLicenseAnnotations(pts *corev1.PodTemplateSpec, la *wlv1.WebSphere
 	ratio := ""
 	switch la.Spec.License.Edition {
 	case wlv1.LicenseEditionBase:
-		ratio = "4:1"
+		if entitlement == wlv1.LicenseEntitlementCP4AppsAdvanced {
+			ratio = "11:2"
+		} else {
+			ratio = "4:1"
+		}
 	case wlv1.LicenseEditionCore:
-		ratio = "8:1"
+		if entitlement == wlv1.LicenseEntitlementCP4AppsAdvanced {
+			ratio = "11:1"
+		} else {
+			ratio = "8:1"
+		}
 	case wlv1.LicenseEditionND:
-		ratio = "1:1"
+		if entitlement == wlv1.LicenseEntitlementCP4AppsAdvanced {
+			ratio = "3:2"
+		} else {
+			ratio = "1:1"
+		}
 	default:
 		ratio = "4:1"
 	}
+
 	pts.Annotations[productNameKey] = string(la.Spec.License.Edition)
 
 	if entitlement == wlv1.LicenseEntitlementStandalone {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -275,16 +275,22 @@ func TestCustomizeLicenseAnnotations(t *testing.T) {
 	td = append(td, licenseTestData{edition: webspherelibertyv1.LicenseEditionBase, pes: webspherelibertyv1.LicenseEntitlementCP4Apps})
 	td = append(td, licenseTestData{edition: webspherelibertyv1.LicenseEditionBase, pes: webspherelibertyv1.LicenseEntitlementFamilyEdition})
 	td = append(td, licenseTestData{edition: webspherelibertyv1.LicenseEditionBase, pes: webspherelibertyv1.LicenseEntitlementWSHE})
+	td = append(td, licenseTestData{edition: webspherelibertyv1.LicenseEditionBase, pes: webspherelibertyv1.LicenseEntitlementCP4AppsAdvanced})
+	td = append(td, licenseTestData{edition: webspherelibertyv1.LicenseEditionBase, pes: webspherelibertyv1.LicenseEntitlementCP4AppsStandard})
 
 	td = append(td, licenseTestData{edition: webspherelibertyv1.LicenseEditionCore, pes: webspherelibertyv1.LicenseEntitlementStandalone})
 	td = append(td, licenseTestData{edition: webspherelibertyv1.LicenseEditionCore, pes: webspherelibertyv1.LicenseEntitlementCP4Apps})
 	td = append(td, licenseTestData{edition: webspherelibertyv1.LicenseEditionCore, pes: webspherelibertyv1.LicenseEntitlementFamilyEdition})
 	td = append(td, licenseTestData{edition: webspherelibertyv1.LicenseEditionCore, pes: webspherelibertyv1.LicenseEntitlementWSHE})
+	td = append(td, licenseTestData{edition: webspherelibertyv1.LicenseEditionCore, pes: webspherelibertyv1.LicenseEntitlementCP4AppsAdvanced})
+	td = append(td, licenseTestData{edition: webspherelibertyv1.LicenseEditionCore, pes: webspherelibertyv1.LicenseEntitlementCP4AppsStandard})
 
 	td = append(td, licenseTestData{edition: webspherelibertyv1.LicenseEditionND, pes: webspherelibertyv1.LicenseEntitlementStandalone})
 	td = append(td, licenseTestData{edition: webspherelibertyv1.LicenseEditionND, pes: webspherelibertyv1.LicenseEntitlementCP4Apps})
 	td = append(td, licenseTestData{edition: webspherelibertyv1.LicenseEditionND, pes: webspherelibertyv1.LicenseEntitlementFamilyEdition})
 	td = append(td, licenseTestData{edition: webspherelibertyv1.LicenseEditionND, pes: webspherelibertyv1.LicenseEntitlementWSHE})
+	td = append(td, licenseTestData{edition: webspherelibertyv1.LicenseEditionND, pes: webspherelibertyv1.LicenseEntitlementCP4AppsAdvanced})
+	td = append(td, licenseTestData{edition: webspherelibertyv1.LicenseEditionND, pes: webspherelibertyv1.LicenseEntitlementCP4AppsStandard})
 
 	for _, s := range td {
 		t.Logf("Testing %#v\n", s)
@@ -353,8 +359,8 @@ func TestCustomizeLicenseAnnotations(t *testing.T) {
 				t.Errorf("cloudpakId should not exist but was %s\n", pts.Annotations["cloudpakId"])
 			}
 		} else {
-			if !checkRatio(pts.Annotations["productCloudpakRatio"], s.edition) {
-				t.Errorf("Unexpected productCloudpakRatio %s for edition %s\n", pts.Annotations["productCloudpakRatio"], s.edition)
+			if !checkRatio(pts.Annotations["productCloudpakRatio"], s.edition, s.pes) {
+				t.Errorf("Unexpected productCloudpakRatio %s for edition %s and entitlement %s\n", pts.Annotations["productCloudpakRatio"], s.edition, s.pes)
 			}
 			if !checkID(pts.Annotations["cloudpakId"], s.pes) {
 				t.Errorf("Unexpected cloudpakId %s for entitlement %s\n", pts.Annotations["cloudpakId"], s.pes)
@@ -367,7 +373,16 @@ func TestCustomizeLicenseAnnotations(t *testing.T) {
 	}
 }
 
-func checkRatio(ratio string, edition webspherelibertyv1.LicenseEdition) bool {
+func checkRatio(ratio string, edition webspherelibertyv1.LicenseEdition, pes webspherelibertyv1.LicenseEntitlement) bool {
+	if ratio == "11:2" && edition == webspherelibertyv1.LicenseEditionBase && pes == webspherelibertyv1.LicenseEntitlementCP4Apps {
+		return true
+	}
+	if ratio == "11:1" && edition == webspherelibertyv1.LicenseEditionCore && pes == webspherelibertyv1.LicenseEntitlementCP4Apps {
+		return true
+	}
+	if ratio == "3:2" && edition == webspherelibertyv1.LicenseEditionND && pes == webspherelibertyv1.LicenseEntitlementCP4Apps {
+		return true
+	}
 	if ratio == "4:1" && edition == webspherelibertyv1.LicenseEditionBase {
 		return true
 	}
@@ -387,6 +402,12 @@ func checkID(id string, pes webspherelibertyv1.LicenseEntitlement) bool {
 		return true
 	}
 	if id == "6358611af04743f99f42dadcd6e39d52" && pes == webspherelibertyv1.LicenseEntitlementWSHE {
+		return true
+	}
+	if id == "4df52d2cdc374ba09f631a650ad2b5bf" && pes == webspherelibertyv1.LicenseEntitlementCP4AppsStandard {
+		return true
+	}
+	if id == "217562c7767641d982cc6df6bcb5cb87" && pes == webspherelibertyv1.LicenseEntitlementCP4AppsAdvanced {
 		return true
 	}
 	return false

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -374,23 +374,26 @@ func TestCustomizeLicenseAnnotations(t *testing.T) {
 }
 
 func checkRatio(ratio string, edition webspherelibertyv1.LicenseEdition, pes webspherelibertyv1.LicenseEntitlement) bool {
-	if ratio == "11:2" && edition == webspherelibertyv1.LicenseEditionBase && pes == webspherelibertyv1.LicenseEntitlementCP4Apps {
-		return true
-	}
-	if ratio == "11:1" && edition == webspherelibertyv1.LicenseEditionCore && pes == webspherelibertyv1.LicenseEntitlementCP4Apps {
-		return true
-	}
-	if ratio == "3:2" && edition == webspherelibertyv1.LicenseEditionND && pes == webspherelibertyv1.LicenseEntitlementCP4Apps {
-		return true
-	}
-	if ratio == "4:1" && edition == webspherelibertyv1.LicenseEditionBase {
-		return true
-	}
-	if ratio == "8:1" && edition == webspherelibertyv1.LicenseEditionCore {
-		return true
-	}
-	if ratio == "1:1" && edition == webspherelibertyv1.LicenseEditionND {
-		return true
+	if pes == webspherelibertyv1.LicenseEntitlementCP4AppsAdvanced {
+		if ratio == "11:2" && edition == webspherelibertyv1.LicenseEditionBase {
+			return true
+		}
+		if ratio == "11:1" && edition == webspherelibertyv1.LicenseEditionCore {
+			return true
+		}
+		if ratio == "3:2" && edition == webspherelibertyv1.LicenseEditionND {
+			return true
+		}
+	} else {
+		if ratio == "4:1" && edition == webspherelibertyv1.LicenseEditionBase {
+			return true
+		}
+		if ratio == "8:1" && edition == webspherelibertyv1.LicenseEditionCore {
+			return true
+		}
+		if ratio == "1:1" && edition == webspherelibertyv1.LicenseEditionND {
+			return true
+		}
 	}
 	return false
 }


### PR DESCRIPTION
- Add support for the new `Cloud Pak for Applications Advanced` entitlement
- Add `Cloud Pak for Applications Standard` explicitly to differentiate. This is same as the current `Cloud Pak for Applications` option, which we have to continue to list as an option to avoid breaking existing users who might have chosen this enum value
- Update unit tests

Additional information: https://github.com/WASdev/websphere-liberty-operator/issues/628#issuecomment-2226358882