### PR TITLE
Add support for Pod DNS policy and config

### DIFF
--- a/api/v1/webspherelibertyapplication_types.go
+++ b/api/v1/webspherelibertyapplication_types.go
@@ -175,6 +175,21 @@ type WebSphereLibertyApplicationSpec struct {
 	// Tolerations to be added to application pods. Tolerations allow the scheduler to schedule pods on nodes with matching taints.
 	// +operator-sdk:csv:customresourcedefinitions:order=34,type=spec,displayName="Tolerations"
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+
+	// DNS settings for the application pod.
+	// +operator-sdk:csv:customresourcedefinitions:order=35,type=spec,displayName="DNS"
+	DNS *WebSphereLibertyApplicationDNS `json:"dns,omitempty"`
+}
+
+// Defines the DNS
+type WebSphereLibertyApplicationDNS struct {
+	// The DNS Policy for the application pod. Defaults to ClusterFirst.
+	// +operator-sdk:csv:customresourcedefinitions:order=1,type=spec,displayName="DNS Policy"
+	DNSPolicy *corev1.DNSPolicy `json:"policy,omitempty"`
+
+	// The DNS Config for the application pod.
+	// +operator-sdk:csv:customresourcedefinitions:order=2,type=spec,displayName="DNS Config"
+	PodDNSConfig *corev1.PodDNSConfig `json:"config,omitempty"`
 }
 
 type License struct {
@@ -247,7 +262,7 @@ type WebSphereLibertyApplicationTopologySpreadConstraints struct {
 	Constraints *[]corev1.TopologySpreadConstraint `json:"constraints,omitempty"`
 
 	// Whether the operator should disable its default set of TopologySpreadConstraints. Defaults to false.
-	// +operator-sdk:csv:customresourcedefinitions:order=1,type=spec,displayName="Disable Operator Defaults",xDescriptors="urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+	// +operator-sdk:csv:customresourcedefinitions:order=2,type=spec,displayName="Disable Operator Defaults",xDescriptors="urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
 	DisableOperatorDefaults *bool `json:"disableOperatorDefaults,omitempty"`
 }
 
@@ -1273,6 +1288,21 @@ func (cr *WebSphereLibertyApplication) GetDisableServiceLinks() *bool {
 // GetToleration returns pod tolerations slice
 func (cr *WebSphereLibertyApplication) GetTolerations() []corev1.Toleration {
 	return cr.Spec.Tolerations
+}
+
+func (cr *WebSphereLibertyApplication) GetDNS() common.BaseComponentDNS {
+	if cr.Spec.DNS == nil {
+		return nil
+	}
+	return cr.Spec.DNS
+}
+
+func (d *WebSphereLibertyApplicationDNS) GetPolicy() *corev1.DNSPolicy {
+	return d.DNSPolicy
+}
+
+func (d *WebSphereLibertyApplicationDNS) GetConfig() *corev1.PodDNSConfig {
+	return d.PodDNSConfig
 }
 
 // Initialize sets default values


### PR DESCRIPTION
For issue https://github.com/OpenLiberty/open-liberty-operator/issues/516
- Adds BaseComponentDNS
- Implements RuntimeComponentDNS at `.spec.dns` with attributes 
    - `.spec.dns.policy` (`corev1.DNSPolicy`)
    - `.spec.dns.config` (`corev1.PodDNSConfig`)