### PR TITLE
Support multi resource sharing

### DIFF
--- a/api/v1/webspherelibertyapplication_types.go
+++ b/api/v1/webspherelibertyapplication_types.go
@@ -74,110 +74,114 @@ type WebSphereLibertyApplicationSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:order=8,type=spec,displayName="Expose",xDescriptors="urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
 	Expose *bool `json:"expose,omitempty"`
 
+	// Enable management of password encryption key sharing amongst Liberty containers. Defaults to false.
+	// +operator-sdk:csv:customresourcedefinitions:order=9,type=spec,displayName="Manage Password Encryption",xDescriptors="urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+	ManagePasswordEncryption *bool `json:"managePasswordEncryption,omitempty"`
+
 	// Enable management of LTPA key sharing amongst Liberty containers. Defaults to false.
-	// +operator-sdk:csv:customresourcedefinitions:order=9,type=spec,displayName="Manage LTPA",xDescriptors="urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+	// +operator-sdk:csv:customresourcedefinitions:order=10,type=spec,displayName="Manage LTPA",xDescriptors="urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
 	ManageLTPA *bool `json:"manageLTPA,omitempty"`
 
 	// Enable management of TLS certificates. Defaults to true.
-	// +operator-sdk:csv:customresourcedefinitions:order=10,type=spec,displayName="Manage TLS",xDescriptors="urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+	// +operator-sdk:csv:customresourcedefinitions:order=11,type=spec,displayName="Manage TLS",xDescriptors="urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
 	ManageTLS *bool `json:"manageTLS,omitempty"`
 
 	// Number of pods to create. Defaults to 1. Not applicable when .spec.autoscaling or .spec.createKnativeService is specified.
-	// +operator-sdk:csv:customresourcedefinitions:order=11,type=spec,displayName="Replicas",xDescriptors="urn:alm:descriptor:com.tectonic.ui:podCount"
+	// +operator-sdk:csv:customresourcedefinitions:order=12,type=spec,displayName="Replicas",xDescriptors="urn:alm:descriptor:com.tectonic.ui:podCount"
 	Replicas *int32 `json:"replicas,omitempty"`
 
-	// +operator-sdk:csv:customresourcedefinitions:order=12,type=spec,displayName="Auto Scaling"
+	// +operator-sdk:csv:customresourcedefinitions:order=13,type=spec,displayName="Auto Scaling"
 	Autoscaling *WebSphereLibertyApplicationAutoScaling `json:"autoscaling,omitempty"`
 
 	// Resource requests and limits for the application container.
-	// +operator-sdk:csv:customresourcedefinitions:order=13,type=spec,displayName="Resource Requirements",xDescriptors="urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+	// +operator-sdk:csv:customresourcedefinitions:order=14,type=spec,displayName="Resource Requirements",xDescriptors="urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 
-	// +operator-sdk:csv:customresourcedefinitions:order=14,type=spec,displayName="Probes"
+	// +operator-sdk:csv:customresourcedefinitions:order=15,type=spec,displayName="Probes"
 	Probes *WebSphereLibertyApplicationProbes `json:"probes,omitempty"`
 
-	// +operator-sdk:csv:customresourcedefinitions:order=15,type=spec,displayName="Deployment"
+	// +operator-sdk:csv:customresourcedefinitions:order=16,type=spec,displayName="Deployment"
 	Deployment *WebSphereLibertyApplicationDeployment `json:"deployment,omitempty"`
 
-	// +operator-sdk:csv:customresourcedefinitions:order=16,type=spec,displayName="StatefulSet"
+	// +operator-sdk:csv:customresourcedefinitions:order=17,type=spec,displayName="StatefulSet"
 	StatefulSet *WebSphereLibertyApplicationStatefulSet `json:"statefulSet,omitempty"`
 
-	// +operator-sdk:csv:customresourcedefinitions:order=17,type=spec,displayName="Service"
+	// +operator-sdk:csv:customresourcedefinitions:order=18,type=spec,displayName="Service"
 	Service *WebSphereLibertyApplicationService `json:"service,omitempty"`
 
-	// +operator-sdk:csv:customresourcedefinitions:order=18,type=spec,displayName="Route"
+	// +operator-sdk:csv:customresourcedefinitions:order=19,type=spec,displayName="Route"
 	Route *WebSphereLibertyApplicationRoute `json:"route,omitempty"`
 
 	// Configures the Semeru Cloud Compiler to handle Just-In-Time (JIT) compilation requests from the application.
-	// +operator-sdk:csv:customresourcedefinitions:order=19,type=spec,displayName="Semeru Cloud Compiler"
+	// +operator-sdk:csv:customresourcedefinitions:order=20,type=spec,displayName="Semeru Cloud Compiler"
 	SemeruCloudCompiler *WebSphereLibertyApplicationSemeruCloudCompiler `json:"semeruCloudCompiler,omitempty"`
 
-	// +operator-sdk:csv:customresourcedefinitions:order=20,type=spec,displayName="Network Policy"
+	// +operator-sdk:csv:customresourcedefinitions:order=21,type=spec,displayName="Network Policy"
 	NetworkPolicy *WebSphereLibertyApplicationNetworkPolicy `json:"networkPolicy,omitempty"`
 
-	// +operator-sdk:csv:customresourcedefinitions:order=21,type=spec,displayName="Serviceability"
+	// +operator-sdk:csv:customresourcedefinitions:order=22,type=spec,displayName="Serviceability"
 	Serviceability *WebSphereLibertyApplicationServiceability `json:"serviceability,omitempty"`
 
-	// +operator-sdk:csv:customresourcedefinitions:order=22,type=spec,displayName="Single Sign-On"
+	// +operator-sdk:csv:customresourcedefinitions:order=23,type=spec,displayName="Single Sign-On"
 	SSO *WebSphereLibertyApplicationSSO `json:"sso,omitempty"`
 
-	// +operator-sdk:csv:customresourcedefinitions:order=23,type=spec,displayName="Monitoring"
+	// +operator-sdk:csv:customresourcedefinitions:order=24,type=spec,displayName="Monitoring"
 	Monitoring *WebSphereLibertyApplicationMonitoring `json:"monitoring,omitempty"`
 
 	// An array of environment variables for the application container.
 	// +listType=map
 	// +listMapKey=name
-	// +operator-sdk:csv:customresourcedefinitions:order=24,type=spec,displayName="Environment Variables"
+	// +operator-sdk:csv:customresourcedefinitions:order=25,type=spec,displayName="Environment Variables"
 	Env []corev1.EnvVar `json:"env,omitempty"`
 
 	// List of sources to populate environment variables in the application container.
 	// +listType=atomic
-	// +operator-sdk:csv:customresourcedefinitions:order=25,type=spec,displayName="Environment Variables from Sources"
+	// +operator-sdk:csv:customresourcedefinitions:order=26,type=spec,displayName="Environment Variables from Sources"
 	EnvFrom []corev1.EnvFromSource `json:"envFrom,omitempty"`
 
 	// Represents a volume with data that is accessible to the application container.
 	// +listType=map
 	// +listMapKey=name
-	// +operator-sdk:csv:customresourcedefinitions:order=26,type=spec,displayName="Volumes"
+	// +operator-sdk:csv:customresourcedefinitions:order=27,type=spec,displayName="Volumes"
 	Volumes []corev1.Volume `json:"volumes,omitempty"`
 
 	// Represents where to mount the volumes into the application container.
 	// +listType=atomic
-	// +operator-sdk:csv:customresourcedefinitions:order=27,type=spec,displayName="Volume Mounts"
+	// +operator-sdk:csv:customresourcedefinitions:order=28,type=spec,displayName="Volume Mounts"
 	VolumeMounts []corev1.VolumeMount `json:"volumeMounts,omitempty"`
 
 	// List of containers to run before other containers in a pod.
 	// +listType=map
 	// +listMapKey=name
-	// +operator-sdk:csv:customresourcedefinitions:order=28,type=spec,displayName="Init Containers"
+	// +operator-sdk:csv:customresourcedefinitions:order=29,type=spec,displayName="Init Containers"
 	InitContainers []corev1.Container `json:"initContainers,omitempty"`
 
 	// List of sidecar containers. These are additional containers to be added to the pods.
 	// +listType=map
 	// +listMapKey=name
-	// +operator-sdk:csv:customresourcedefinitions:order=29,type=spec,displayName="Sidecar Containers"
+	// +operator-sdk:csv:customresourcedefinitions:order=30,type=spec,displayName="Sidecar Containers"
 	SidecarContainers []corev1.Container `json:"sidecarContainers,omitempty"`
 
-	// +operator-sdk:csv:customresourcedefinitions:order=30,type=spec,displayName="Affinity"
+	// +operator-sdk:csv:customresourcedefinitions:order=31,type=spec,displayName="Affinity"
 	Affinity *WebSphereLibertyApplicationAffinity `json:"affinity,omitempty"`
 
 	// Security context for the application container.
-	// +operator-sdk:csv:customresourcedefinitions:order=31,type=spec,displayName="Security Context"
+	// +operator-sdk:csv:customresourcedefinitions:order=32,type=spec,displayName="Security Context"
 	SecurityContext *corev1.SecurityContext `json:"securityContext,omitempty"`
 
-	// +operator-sdk:csv:customresourcedefinitions:order=26,type=spec,displayName="Topology Spread Constraints"
+	// +operator-sdk:csv:customresourcedefinitions:order=33,type=spec,displayName="Topology Spread Constraints"
 	TopologySpreadConstraints *WebSphereLibertyApplicationTopologySpreadConstraints `json:"topologySpreadConstraints,omitempty"`
 
 	// Disable information about services being injected into the application pod's environment variables. Default to false.
-	// +operator-sdk:csv:customresourcedefinitions:order=33,type=spec,displayName="Disable Service Links",xDescriptors="urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+	// +operator-sdk:csv:customresourcedefinitions:order=34,type=spec,displayName="Disable Service Links",xDescriptors="urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
 	DisableServiceLinks *bool `json:"disableServiceLinks,omitempty"`
 
 	// Tolerations to be added to application pods. Tolerations allow the scheduler to schedule pods on nodes with matching taints.
-	// +operator-sdk:csv:customresourcedefinitions:order=34,type=spec,displayName="Tolerations"
+	// +operator-sdk:csv:customresourcedefinitions:order=35,type=spec,displayName="Tolerations"
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 
 	// DNS settings for the application pod.
-	// +operator-sdk:csv:customresourcedefinitions:order=35,type=spec,displayName="DNS"
+	// +operator-sdk:csv:customresourcedefinitions:order=36,type=spec,displayName="DNS"
 	DNS *WebSphereLibertyApplicationDNS `json:"dns,omitempty"`
 }
 
@@ -850,6 +854,11 @@ func (cr *WebSphereLibertyApplication) GetResourceConstraints() *corev1.Resource
 // GetExpose returns expose flag
 func (cr *WebSphereLibertyApplication) GetExpose() *bool {
 	return cr.Spec.Expose
+}
+
+// GetManagePasswordEncryption returns the Password Encryption key sharing status
+func (cr *WebSphereLibertyApplication) GetManagePasswordEncryption() *bool {
+	return cr.Spec.ManagePasswordEncryption
 }
 
 // GetManageLTPA returns the LTPA key sharing status

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -788,6 +788,11 @@ func (in *WebSphereLibertyApplicationSpec) DeepCopyInto(out *WebSphereLibertyApp
 		*out = new(bool)
 		**out = **in
 	}
+	if in.ManagePasswordEncryption != nil {
+		in, out := &in.ManagePasswordEncryption, &out.ManagePasswordEncryption
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ManageLTPA != nil {
 		in, out := &in.ManageLTPA, &out.ManageLTPA
 		*out = new(bool)

--- a/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
@@ -61,7 +61,7 @@ metadata:
     capabilities: Auto Pilot
     categories: Application Runtime
     containerImage: icr.io/cpopen/websphere-liberty-operator:daily
-    createdAt: "2024-08-29T22:18:47Z"
+    createdAt: "2024-08-30T19:19:58Z"
     description: Deploy and manage containerized Liberty applications
     olm.skipRange: '>=1.0.0 <1.4.0'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
@@ -258,10 +258,10 @@ spec:
       - description: Specifies one or more scopes to request.
         displayName: Scope
         path: sso.oidc[0].scope
-      - description: Enable management of LTPA key sharing amongst Liberty containers.
-          Defaults to false.
-        displayName: Manage LTPA
-        path: manageLTPA
+      - description: Enable management of password encryption key sharing amongst
+          Liberty containers. Defaults to false.
+        displayName: Manage Password Encryption
+        path: managePasswordEncryption
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: The port exposed by the container.
@@ -272,9 +272,10 @@ spec:
       - description: Specifies the required authentication method.
         displayName: Token Endpoint Auth Method
         path: sso.oidc[0].tokenEndpointAuthMethod
-      - description: Enable management of TLS certificates. Defaults to true.
-        displayName: Manage TLS
-        path: manageTLS
+      - description: Enable management of LTPA key sharing amongst Liberty containers.
+          Defaults to false.
+        displayName: Manage LTPA
+        path: manageLTPA
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - displayName: Service Type
@@ -287,29 +288,29 @@ spec:
         path: sso.oidc[0].hostNameVerificationEnabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Enable management of TLS certificates. Defaults to true.
+        displayName: Manage TLS
+        path: manageTLS
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Node proxies this port into your service.
+        displayName: Node Port
+        path: service.nodePort
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
       - description: Number of pods to create. Defaults to 1. Not applicable when
           .spec.autoscaling or .spec.createKnativeService is specified.
         displayName: Replicas
         path: replicas
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:podCount
-      - description: Node proxies this port into your service.
-        displayName: Node Port
-        path: service.nodePort
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:number
-      - displayName: Auto Scaling
-        path: autoscaling
       - description: The name for the port exposed by the container.
         displayName: Port Name
         path: service.portName
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Resource requests and limits for the application container.
-        displayName: Resource Requirements
-        path: resources
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - displayName: Auto Scaling
+        path: autoscaling
       - description: Annotations to be added to the service.
         displayName: Service Annotations
         path: service.annotations
@@ -320,16 +321,19 @@ spec:
         path: service.certificate.annotations
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - displayName: Probes
-        path: probes
+      - description: Resource requests and limits for the application container.
+        displayName: Resource Requirements
+        path: resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - description: The port that the operator assigns to containers inside pods.
           Defaults to the value of .spec.service.port.
         displayName: Target Port
         path: service.targetPort
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
-      - displayName: Deployment
-        path: deployment
+      - displayName: Probes
+        path: probes
       - description: 'A name of a secret that already contains TLS key, certificate
           and CA to be mounted in the pod. The following keys are valid in the secret:
           ca.crt, tls.crt, and tls.key.'
@@ -337,89 +341,89 @@ spec:
         path: service.certificateSecretRef
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Deployment
+        path: deployment
       - description: Configure service certificate.
         displayName: Service Certificate
         path: service.certificate
+      - description: An array consisting of service ports.
+        displayName: Ports
+        path: service.ports
       - displayName: StatefulSet
         path: statefulSet
       - displayName: Service
         path: service
-      - description: An array consisting of service ports.
-        displayName: Ports
-        path: service.ports
-      - displayName: Route
-        path: route
       - description: Expose the application as a bindable service. Defaults to false.
         displayName: Bindable
         path: service.bindable
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - displayName: Route
+        path: route
       - description: Configures the Semeru Cloud Compiler to handle Just-In-Time (JIT)
           compilation requests from the application.
         displayName: Semeru Cloud Compiler
         path: semeruCloudCompiler
-      - displayName: Network Policy
-        path: networkPolicy
       - description: Specifies the strategy to replace old deployment pods with new
           pods.
         displayName: Deployment Update Strategy
         path: deployment.updateStrategy
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:updateStrategy
+      - displayName: Network Policy
+        path: networkPolicy
       - displayName: Serviceability
         path: serviceability
       - displayName: Single Sign-On
         path: sso
-      - displayName: Monitoring
-        path: monitoring
       - description: Specifies the strategy to replace old StatefulSet pods with new
           pods.
         displayName: StatefulSet Update Strategy
         path: statefulSet.updateStrategy
+      - displayName: Monitoring
+        path: monitoring
+      - displayName: Storage
+        path: statefulSet.storage
       - description: An array of environment variables for the application container.
         displayName: Environment Variables
         path: env
-      - displayName: Storage
-        path: statefulSet.storage
-      - description: List of sources to populate environment variables in the application
-          container.
-        displayName: Environment Variables from Sources
-        path: envFrom
       - description: A convenient field to set the size of the persisted storage.
         displayName: Storage Size
         path: statefulSet.storage.size
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: List of sources to populate environment variables in the application
+          container.
+        displayName: Environment Variables from Sources
+        path: envFrom
       - description: A convenient field to request the storage class of the persisted
           storage. The name can not be specified or updated after the storage is created.
         displayName: Storage Class Name
         path: statefulSet.storage.className
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - displayName: Topology Spread Constraints
-        path: topologySpreadConstraints
-      - description: Represents a volume with data that is accessible to the application
-          container.
-        displayName: Volumes
-        path: volumes
       - description: The directory inside the container where this persisted storage
           will be bound to.
         displayName: Storage Mount Path
         path: statefulSet.storage.mountPath
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Represents where to mount the volumes into the application container.
-        displayName: Volume Mounts
-        path: volumeMounts
-      - description: List of containers to run before other containers in a pod.
-        displayName: Init Containers
-        path: initContainers
+      - description: Represents a volume with data that is accessible to the application
+          container.
+        displayName: Volumes
+        path: volumes
       - description: A YAML object that represents a volumeClaimTemplate component
           of a StatefulSet.
         displayName: Storage Volume Claim Template
         path: statefulSet.storage.volumeClaimTemplate
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:PersistentVolumeClaim
+      - description: Represents where to mount the volumes into the application container.
+        displayName: Volume Mounts
+        path: volumeMounts
+      - description: List of containers to run before other containers in a pod.
+        displayName: Init Containers
+        path: initContainers
       - description: List of sidecar containers. These are additional containers to
           be added to the pods.
         displayName: Sidecar Containers
@@ -429,6 +433,8 @@ spec:
       - description: Security context for the application container.
         displayName: Security Context
         path: securityContext
+      - displayName: Topology Spread Constraints
+        path: topologySpreadConstraints
       - description: Disable information about services being injected into the application
           pod's environment variables. Default to false.
         displayName: Disable Service Links
@@ -440,6 +446,12 @@ spec:
         path: monitoring.labels
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: A YAML snippet representing an array of Endpoint component from
+          ServiceMonitor.
+        displayName: Monitoring Endpoints
+        path: monitoring.endpoints
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:endpointList
       - description: Tolerations to be added to application pods. Tolerations allow
           the scheduler to schedule pods on nodes with matching taints.
         displayName: Tolerations
@@ -447,12 +459,6 @@ spec:
       - description: DNS settings for the application pod.
         displayName: DNS
         path: dns
-      - description: A YAML snippet representing an array of Endpoint component from
-          ServiceMonitor.
-        displayName: Monitoring Endpoints
-        path: monitoring.endpoints
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:endpointList
       - description: Controls which nodes the pod are scheduled to run on, based on
           labels on the node.
         displayName: Node Affinity

--- a/bundle/manifests/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
+++ b/bundle/manifests/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
@@ -2563,6 +2563,10 @@ spec:
                 description: Enable management of LTPA key sharing amongst Liberty
                   containers. Defaults to false.
                 type: boolean
+              managePasswordEncryption:
+                description: Enable management of password encryption key sharing
+                  amongst Liberty containers. Defaults to false.
+                type: boolean
               manageTLS:
                 description: Enable management of TLS certificates. Defaults to true.
                 type: boolean

--- a/config/crd/bases/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
+++ b/config/crd/bases/liberty.websphere.ibm.com_webspherelibertyapplications.yaml
@@ -2559,6 +2559,10 @@ spec:
                 description: Enable management of LTPA key sharing amongst Liberty
                   containers. Defaults to false.
                 type: boolean
+              managePasswordEncryption:
+                description: Enable management of password encryption key sharing
+                  amongst Liberty containers. Defaults to false.
+                type: boolean
               manageTLS:
                 description: Enable management of TLS certificates. Defaults to true.
                 type: boolean

--- a/config/manifests/bases/ibm-websphere-liberty.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-websphere-liberty.clusterserviceversion.yaml
@@ -200,10 +200,10 @@ spec:
       - description: Specifies one or more scopes to request.
         displayName: Scope
         path: sso.oidc[0].scope
-      - description: Enable management of LTPA key sharing amongst Liberty containers.
-          Defaults to false.
-        displayName: Manage LTPA
-        path: manageLTPA
+      - description: Enable management of password encryption key sharing amongst
+          Liberty containers. Defaults to false.
+        displayName: Manage Password Encryption
+        path: managePasswordEncryption
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: The port exposed by the container.
@@ -214,9 +214,10 @@ spec:
       - description: Specifies the required authentication method.
         displayName: Token Endpoint Auth Method
         path: sso.oidc[0].tokenEndpointAuthMethod
-      - description: Enable management of TLS certificates. Defaults to true.
-        displayName: Manage TLS
-        path: manageTLS
+      - description: Enable management of LTPA key sharing amongst Liberty containers.
+          Defaults to false.
+        displayName: Manage LTPA
+        path: manageLTPA
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - displayName: Service Type
@@ -229,29 +230,29 @@ spec:
         path: sso.oidc[0].hostNameVerificationEnabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Enable management of TLS certificates. Defaults to true.
+        displayName: Manage TLS
+        path: manageTLS
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Node proxies this port into your service.
+        displayName: Node Port
+        path: service.nodePort
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
       - description: Number of pods to create. Defaults to 1. Not applicable when
           .spec.autoscaling or .spec.createKnativeService is specified.
         displayName: Replicas
         path: replicas
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:podCount
-      - description: Node proxies this port into your service.
-        displayName: Node Port
-        path: service.nodePort
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:number
-      - displayName: Auto Scaling
-        path: autoscaling
       - description: The name for the port exposed by the container.
         displayName: Port Name
         path: service.portName
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Resource requests and limits for the application container.
-        displayName: Resource Requirements
-        path: resources
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - displayName: Auto Scaling
+        path: autoscaling
       - description: Annotations to be added to the service.
         displayName: Service Annotations
         path: service.annotations
@@ -262,16 +263,19 @@ spec:
         path: service.certificate.annotations
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - displayName: Probes
-        path: probes
+      - description: Resource requests and limits for the application container.
+        displayName: Resource Requirements
+        path: resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - description: The port that the operator assigns to containers inside pods.
           Defaults to the value of .spec.service.port.
         displayName: Target Port
         path: service.targetPort
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
-      - displayName: Deployment
-        path: deployment
+      - displayName: Probes
+        path: probes
       - description: 'A name of a secret that already contains TLS key, certificate
           and CA to be mounted in the pod. The following keys are valid in the secret:
           ca.crt, tls.crt, and tls.key.'
@@ -279,89 +283,89 @@ spec:
         path: service.certificateSecretRef
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Deployment
+        path: deployment
       - description: Configure service certificate.
         displayName: Service Certificate
         path: service.certificate
+      - description: An array consisting of service ports.
+        displayName: Ports
+        path: service.ports
       - displayName: StatefulSet
         path: statefulSet
       - displayName: Service
         path: service
-      - description: An array consisting of service ports.
-        displayName: Ports
-        path: service.ports
-      - displayName: Route
-        path: route
       - description: Expose the application as a bindable service. Defaults to false.
         displayName: Bindable
         path: service.bindable
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - displayName: Route
+        path: route
       - description: Configures the Semeru Cloud Compiler to handle Just-In-Time (JIT)
           compilation requests from the application.
         displayName: Semeru Cloud Compiler
         path: semeruCloudCompiler
-      - displayName: Network Policy
-        path: networkPolicy
       - description: Specifies the strategy to replace old deployment pods with new
           pods.
         displayName: Deployment Update Strategy
         path: deployment.updateStrategy
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:updateStrategy
+      - displayName: Network Policy
+        path: networkPolicy
       - displayName: Serviceability
         path: serviceability
       - displayName: Single Sign-On
         path: sso
-      - displayName: Monitoring
-        path: monitoring
       - description: Specifies the strategy to replace old StatefulSet pods with new
           pods.
         displayName: StatefulSet Update Strategy
         path: statefulSet.updateStrategy
+      - displayName: Monitoring
+        path: monitoring
+      - displayName: Storage
+        path: statefulSet.storage
       - description: An array of environment variables for the application container.
         displayName: Environment Variables
         path: env
-      - displayName: Storage
-        path: statefulSet.storage
-      - description: List of sources to populate environment variables in the application
-          container.
-        displayName: Environment Variables from Sources
-        path: envFrom
       - description: A convenient field to set the size of the persisted storage.
         displayName: Storage Size
         path: statefulSet.storage.size
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: List of sources to populate environment variables in the application
+          container.
+        displayName: Environment Variables from Sources
+        path: envFrom
       - description: A convenient field to request the storage class of the persisted
           storage. The name can not be specified or updated after the storage is created.
         displayName: Storage Class Name
         path: statefulSet.storage.className
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - displayName: Topology Spread Constraints
-        path: topologySpreadConstraints
-      - description: Represents a volume with data that is accessible to the application
-          container.
-        displayName: Volumes
-        path: volumes
       - description: The directory inside the container where this persisted storage
           will be bound to.
         displayName: Storage Mount Path
         path: statefulSet.storage.mountPath
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Represents where to mount the volumes into the application container.
-        displayName: Volume Mounts
-        path: volumeMounts
-      - description: List of containers to run before other containers in a pod.
-        displayName: Init Containers
-        path: initContainers
+      - description: Represents a volume with data that is accessible to the application
+          container.
+        displayName: Volumes
+        path: volumes
       - description: A YAML object that represents a volumeClaimTemplate component
           of a StatefulSet.
         displayName: Storage Volume Claim Template
         path: statefulSet.storage.volumeClaimTemplate
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:PersistentVolumeClaim
+      - description: Represents where to mount the volumes into the application container.
+        displayName: Volume Mounts
+        path: volumeMounts
+      - description: List of containers to run before other containers in a pod.
+        displayName: Init Containers
+        path: initContainers
       - description: List of sidecar containers. These are additional containers to
           be added to the pods.
         displayName: Sidecar Containers
@@ -371,6 +375,8 @@ spec:
       - description: Security context for the application container.
         displayName: Security Context
         path: securityContext
+      - displayName: Topology Spread Constraints
+        path: topologySpreadConstraints
       - description: Disable information about services being injected into the application
           pod's environment variables. Default to false.
         displayName: Disable Service Links
@@ -382,6 +388,12 @@ spec:
         path: monitoring.labels
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: A YAML snippet representing an array of Endpoint component from
+          ServiceMonitor.
+        displayName: Monitoring Endpoints
+        path: monitoring.endpoints
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:endpointList
       - description: Tolerations to be added to application pods. Tolerations allow
           the scheduler to schedule pods on nodes with matching taints.
         displayName: Tolerations
@@ -389,12 +401,6 @@ spec:
       - description: DNS settings for the application pod.
         displayName: DNS
         path: dns
-      - description: A YAML snippet representing an array of Endpoint component from
-          ServiceMonitor.
-        displayName: Monitoring Endpoints
-        path: monitoring.endpoints
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:endpointList
       - description: Controls which nodes the pod are scheduled to run on, based on
           labels on the node.
         displayName: Node Affinity

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 )
 
 require (
+	github.com/OpenLiberty/open-liberty-operator v0.8.1-0.20240828211841-f2a529fbd13f // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/blendle/zapdriver v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ contrib.go.opencensus.io/exporter/ocagent v0.7.1-0.20200907061046-05415f1de66d h
 contrib.go.opencensus.io/exporter/ocagent v0.7.1-0.20200907061046-05415f1de66d/go.mod h1:IshRmMJBhDfFj5Y67nVhMYTTIze91RUeT73ipWKs/GY=
 contrib.go.opencensus.io/exporter/prometheus v0.4.2 h1:sqfsYl5GIY/L570iT+l93ehxaWJs2/OwXtiWwew3oAg=
 contrib.go.opencensus.io/exporter/prometheus v0.4.2/go.mod h1:dvEHbiKmgvbr5pjaF9fpw1KeYcjrnC1J8B+JKjsZyRQ=
+github.com/OpenLiberty/open-liberty-operator v0.8.1-0.20240828211841-f2a529fbd13f h1:UAgxGBgPqoKgQuBENbWonFYQnl9h9Y0P27QZIkK5DNI=
+github.com/OpenLiberty/open-liberty-operator v0.8.1-0.20240828211841-f2a529fbd13f/go.mod h1:36e2Er26ka5EfPKN53Ao8uSOZ7Pd6K/sWZ0Outrb2Fo=
 github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20240827210204-41c90b82ea72 h1:V3AYd1XbkQHZGFdZlOX/uBNZlKTSc+obgfa+46/OidI=
 github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20240827210204-41c90b82ea72/go.mod h1:UBJ/yS5p1IOR1W9LEX1RVoqmviqvC9bfhleGVzolnZ0=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=

--- a/internal/controller/assets/create_ltpa_keys.sh
+++ b/internal/controller/assets/create_ltpa_keys.sh
@@ -1,32 +1,24 @@
 #!/bin/bash 
 
-NAMESPACE=$1
-
-LTPA_SECRET_NAME=$2
-
-LTPA_FILE_NAME=$3
-
-ENCODING_TYPE=$4
-
-LTPA_JOB_REQUEST_NAME=$5
-
-KEY_FILE="/tmp/${LTPA_FILE_NAME}" 
-
-ENCODED_KEY_FILE="/tmp/${LTPA_FILE_NAME}-encoded"
-
-NOT_FOUND_LOG_FILE="/tmp/not_found.out"
-
-APISERVER=https://kubernetes.default.svc
-
-SERVICEACCOUNT=/var/run/secrets/kubernetes.io/serviceaccount
-
-TOKEN=$(cat ${SERVICEACCOUNT}/token)
-
-CACERT=${SERVICEACCOUNT}/ca.crt
-
-RETRY_MESSAGE="Delete ConfigMap '$LTPA_JOB_REQUEST_NAME' to run this Job again."
-
-NETWORK_POLICY_MESSAGE="Is a NetworkPolicy blocking the pod's egress traffic? This pod must enable egress traffic to the API server and the cluster's DNS provider."
+NAMESPACE=$1;
+LTPA_SECRET_BASE_NAME=$2;
+LTPA_SECRET_NAME=$3;
+LTPA_FILE_NAME=$4;
+ENCODING_TYPE=$5;
+PASSWORD_KEY_SECRET_NAME=$6;
+ENCRYPTION_KEY_SHARING_ENABLED=$7;
+LTPA_LABEL_KEY=$8;
+LTPA_LABEL_VALUE=$9;
+LTPA_JOB_REQUEST_NAME=${10};
+KEY_FILE="/tmp/${LTPA_FILE_NAME}";
+ENCODED_KEY_FILE="/tmp/${LTPA_FILE_NAME}-encoded";
+NOT_FOUND_LOG_FILE="/tmp/not_found.out";
+APISERVER="https://kubernetes.default.svc";
+SERVICEACCOUNT="/var/run/secrets/kubernetes.io/serviceaccount";
+TOKEN=$(cat ${SERVICEACCOUNT}/token);
+CACERT="${SERVICEACCOUNT}/ca.crt";
+RETRY_MESSAGE="Delete ConfigMap '$LTPA_JOB_REQUEST_NAME' to run this Job again.";
+NETWORK_POLICY_MESSAGE="Is a NetworkPolicy blocking the pod's egress traffic? This pod must enable egress traffic to the API server and the cluster's DNS provider.";
 
 function log() {
     echo "[$(basename ${0%.*})] $1"
@@ -36,9 +28,9 @@ function error() {
     echo "[$(basename ${0%.*})] ERROR: $1"
 }
 
-curl --cacert ${CACERT} --header "Content-Type: application/json" --header "Authorization: Bearer ${TOKEN}" -X GET ${APISERVER}/api/v1/namespaces/${NAMESPACE}/secrets/${LTPA_SECRET_NAME} &> $NOT_FOUND_LOG_FILE
-
-NOT_FOUND_COUNT=$(cat $NOT_FOUND_LOG_FILE | grep -c "NotFound")
+rm -f $NOT_FOUND_LOG_FILE;
+curl --cacert ${CACERT} --header "Content-Type: application/json" --header "Authorization: Bearer ${TOKEN}" -X GET ${APISERVER}/api/v1/namespaces/${NAMESPACE}/secrets/${LTPA_SECRET_NAME} &> $NOT_FOUND_LOG_FILE;
+NOT_FOUND_COUNT=$(cat $NOT_FOUND_LOG_FILE | grep -c "NotFound");
 
 if [ $NOT_FOUND_COUNT -eq 0 ]; then 
     log "Could not validate that Secret '$LTPA_SECRET_NAME' is missing from namespace '$NAMESPACE'."
@@ -58,28 +50,32 @@ if [ $NOT_FOUND_COUNT -eq 0 ]; then
         error "Failed to parse response from the API server."
     fi
     log "$RETRY_MESSAGE"
-    exit 0; 
+    exit 0;
 fi
 
-TIME_SINCE_EPOCH_SECONDS=$(date '+%s')
+rm -f $NOT_FOUND_LOG_FILE;
+curl --cacert ${CACERT} --header "Content-Type: application/json" --header "Authorization: Bearer ${TOKEN}" -X GET ${APISERVER}/api/v1/namespaces/${NAMESPACE}/secrets/${PASSWORD_KEY_SECRET_NAME} &> $NOT_FOUND_LOG_FILE;
+NOT_FOUND_COUNT=$(cat $NOT_FOUND_LOG_FILE | grep -c "NotFound");
+TIME_SINCE_EPOCH_SECONDS=$(date '+%s');
+PASSWORD=$(openssl rand -base64 32);
+if [ "$ENCRYPTION_KEY_SHARING_ENABLED" == "true" ] && [ $NOT_FOUND_COUNT -eq 0 ]; then 
+    LAST_ROTATION=$(curl --cacert ${CACERT} --header "Content-Type: application/json" --header "Authorization: Bearer ${TOKEN}" -X GET ${APISERVER}/api/v1/namespaces/${NAMESPACE}/secrets/${PASSWORD_KEY_SECRET_NAME} | grep -o '"lastRotation": "[^"]*' | grep -o '[^"]*$' | base64 -d);
+    PASSWORD_KEY=$(curl --cacert ${CACERT} --header "Content-Type: application/json" --header "Authorization: Bearer ${TOKEN}" -X GET ${APISERVER}/api/v1/namespaces/${NAMESPACE}/secrets/${PASSWORD_KEY_SECRET_NAME} | grep -o '"passwordEncryptionKey": "[^"]*' | grep -o '[^"]*$' | base64 -d);
+    securityUtility createLTPAKeys --file=${KEY_FILE} --password=${PASSWORD} --passwordEncoding=${ENCODING_TYPE} --passwordKey=${PASSWORD_KEY} &>/dev/null;
+    cat ${KEY_FILE} | base64 > ${ENCODED_KEY_FILE};
+    ENCODED_PASSWORD=$(securityUtility encode --encoding=${ENCODING_TYPE} --key=${PASSWORD_KEY} ${PASSWORD});
+    BEFORE_LTPA_KEYS="{\"apiVersion\": \"v1\", \"stringData\": {\"encryptionSecretLastRotation\": \"${LAST_ROTATION}\", \"lastRotation\": \"$TIME_SINCE_EPOCH_SECONDS\", \"password\": \"$ENCODED_PASSWORD\"}, \"data\": {\"${LTPA_FILE_NAME}\": \"";
+else
+    securityUtility createLTPAKeys --file=${KEY_FILE} --password=${PASSWORD} --passwordEncoding=${ENCODING_TYPE} &>/dev/null;
+    cat ${KEY_FILE} | base64 > ${ENCODED_KEY_FILE};
+    ENCODED_PASSWORD=$(securityUtility encode --encoding=${ENCODING_TYPE} ${PASSWORD});
+    BEFORE_LTPA_KEYS="{\"apiVersion\": \"v1\", \"stringData\": {\"lastRotation\": \"$TIME_SINCE_EPOCH_SECONDS\", \"password\": \"$ENCODED_PASSWORD\"}, \"data\": {\"${LTPA_FILE_NAME}\": \"";
+fi
 
-PASSWORD=$(openssl rand -base64 15)
-
-securityUtility createLTPAKeys --file=${KEY_FILE} --password=${PASSWORD} --passwordEncoding=${ENCODING_TYPE} &>/dev/null
-
-cat ${KEY_FILE} | base64 > ${ENCODED_KEY_FILE}
-
-ENCODED_PASSWORD=$(securityUtility encode --encoding=${ENCODING_TYPE} ${PASSWORD})
-
-BEFORE_LTPA_KEYS="{\"apiVersion\": \"v1\", \"stringData\": {\"lastRotation\": \"$TIME_SINCE_EPOCH_SECONDS\", \"password\": \"$ENCODED_PASSWORD\"}, \"data\": {\"${LTPA_FILE_NAME}\": \""
-
-AFTER_LTPA_KEYS="\"},\"kind\": \"Secret\",\"metadata\": {\"name\": \"$LTPA_SECRET_NAME\",\"namespace\": \"$NAMESPACE\"},\"type\": \"Opaque\"}"
-
-echo $BEFORE_LTPA_KEYS | cat - ${ENCODED_KEY_FILE} > /tmp/tmp.keys && mv /tmp/tmp.keys ${ENCODED_KEY_FILE}
-
-echo $AFTER_LTPA_KEYS >> ${ENCODED_KEY_FILE}
-
-CREATE_SECRET_STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" --cacert ${CACERT} --header "Content-Type: application/json" --header "Authorization: Bearer ${TOKEN}" -X POST ${APISERVER}/api/v1/namespaces/${NAMESPACE}/secrets --data "@${ENCODED_KEY_FILE}")
+AFTER_LTPA_KEYS="\"},\"kind\": \"Secret\",\"metadata\": {\"name\": \"$LTPA_SECRET_NAME\",\"namespace\": \"$NAMESPACE\",\"labels\": {\"app.kubernetes.io/name\": \"$LTPA_SECRET_BASE_NAME\", \"app.kubernetes.io/instance\": \"$LTPA_SECRET_NAME\", \"$LTPA_LABEL_KEY\": \"$LTPA_LABEL_VALUE\"}},\"type\": \"Opaque\"}";
+echo $BEFORE_LTPA_KEYS | cat - ${ENCODED_KEY_FILE} > /tmp/tmp.keys && mv /tmp/tmp.keys ${ENCODED_KEY_FILE};
+echo $AFTER_LTPA_KEYS >> ${ENCODED_KEY_FILE};
+CREATE_SECRET_STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" --cacert ${CACERT} --header "Content-Type: application/json" --header "Authorization: Bearer ${TOKEN}" -X POST ${APISERVER}/api/v1/namespaces/${NAMESPACE}/secrets --data "@${ENCODED_KEY_FILE}");
 
 if [[ "$CREATE_SECRET_STATUS_CODE" == "201" ]]; then
     log "Successfully created Secret '$LTPA_SECRET_NAME' in namespace '$NAMESPACE'."

--- a/internal/controller/assets/encryption.xml
+++ b/internal/controller/assets/encryption.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <variable name="wlp.password.encryption.key" value="WLP_PASSWORD_ENCRYPTION_KEY" />
+</server>

--- a/internal/controller/assets/ltpa-decision-tree.yaml
+++ b/internal/controller/assets/ltpa-decision-tree.yaml
@@ -1,0 +1,45 @@
+# This file supports multi LTPA key generation across operator versions.
+# Adding a new .tree.<version> is only required when LTPA generation logic has changed.
+#
+# Each "valid path" represents an LTPA key.
+# - a "valid path" can be defined as a string that:
+#     - starts with an operand version string "va.b.c"
+#     - traverses each map/list element by using a period '.'
+#     - terminates at a constant boolean, string
+#     - optionally uses a list as a pre-terminating element but nowhere else
+#
+# In 1.3.2 (1 LTPA key per namespace), there is one possible path "v1_3_2.true" 
+# In 1.4.0 (2 LTPA keys per namespace), there are two possible paths "v1_4_0.managePasswordEncryption.true" and "v1_4_0.managePasswordEncryption.false"
+#
+# The operator will aim to use the latest decision tree version less than or equal to the operator version. 
+# - with operator version 1.6.0, the operator will use .tree.v1_4_0 which is the most up-to-date version
+# - with operator version 1.4.0, the operator will use .tree.v1_4_0
+# - with operator version 1.4.0-alpha, the operator will use .tree.v1_4_0 and ignores the build tags
+# - with operator version 1.3.3, the operator will use .tree.v1_3_3
+# - with operator version 1.3.2, the operator will error saying it could not find any version.
+#
+# This data structure is used in ltpa_keys_sharing.go with reconcileLTPAMetadata() which builds a decision path based on the app instance.
+# 
+tree:
+  v1_3_3: default
+  v1_4_0:
+    managePasswordEncryption:
+      - true
+      - false    
+replace:
+  v1_4_0:
+    "v1_3_3.default": "v1_4_0.managePasswordEncryption.false"
+## An example of how .replace.* is used:
+## In 1.3.2, the singleton LTPA Secret did not have password encryption, so the key represented by path "v1_3_2.true" is the same key as represented by path "v1_4_0.managePasswordEncryption.false"
+## The 1.3.2 operator will create an LTPA Secret and label it "v1_3_2.0" which indicates the path at index 0 for .tree.v1_3_2.
+## The 1.4.0 operator will search LTPA Secrets within the namespace and sees that the "v1_3_2" LTPA Secret could potentially be updated.
+##     It then reads key-values in .replace.v1_4_0 which shows that there is an upgrade path from v1_3_2.true to v1_4_0.managePasswordEncryption.false
+##     The operator will save this new metadata and patch the LTPA Secret's label by updating to "v1_4_0.1" which represents path index 1 for .tree.v1_4_0.
+## Similarly, when the 1.3.2 operator is re-run on the v1_4_0 LTPA Secret, a downgrade will also occur and the LTPA Secret will be patched once again.
+## 
+##
+# replace:
+#   v1_4_0:
+#     "v1_3_2.true": "v1_4_0.managePasswordEncryption.false"
+
+  

--- a/internal/controller/assets/ltpa-signature.yaml
+++ b/internal/controller/assets/ltpa-signature.yaml
@@ -1,0 +1,3 @@
+apiVersion: v1
+kind: Secret
+name: "{0}-managed-ltpa{1}"

--- a/internal/controller/assets/ltpa.xml
+++ b/internal/controller/assets/ltpa.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <ltpa keysFileName="LTPA_KEYS_FILE_NAME" keysPassword="LTPA_KEYS_PASSWORD" />
+</server>

--- a/internal/controller/assets/mount.xml
+++ b/internal/controller/assets/mount.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <include location="MOUNT_LOCATION" />
+</server>

--- a/internal/controller/assets/password-encryption-decision-tree.yaml
+++ b/internal/controller/assets/password-encryption-decision-tree.yaml
@@ -1,0 +1,4 @@
+tree:
+  v1_4_0:
+    managePasswordEncryption: true
+replace: {}

--- a/internal/controller/assets/password-encryption-signature.yaml
+++ b/internal/controller/assets/password-encryption-signature.yaml
@@ -1,0 +1,3 @@
+apiVersion: v1
+kind: Secret
+name: "{0}wlp-password-encryption-key{1}-internal"

--- a/internal/controller/ltpa_keys_sharing.go
+++ b/internal/controller/ltpa_keys_sharing.go
@@ -19,86 +19,172 @@ package controller
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
+	"strconv"
+	"strings"
 
-	v1 "k8s.io/api/batch/v1"
-
-	lutils "github.com/WASdev/websphere-liberty-operator/utils"
-
+	tree "github.com/OpenLiberty/open-liberty-operator/utils/tree"
 	wlv1 "github.com/WASdev/websphere-liberty-operator/api/v1"
-
+	lutils "github.com/WASdev/websphere-liberty-operator/utils"
+	v1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Create the Deployment and Service objects for a Semeru Compiler used by a Websphere Liberty Application
-func (r *ReconcileWebSphereLiberty) reconcileLTPAKeysSharing(instance *wlv1.WebSphereLibertyApplication) (error, string, string) {
-	var ltpaSecretName string
-	var err error
-	if r.isLTPAKeySharingEnabled(instance) {
-		err, ltpaSecretName = r.generateLTPAKeys(instance)
-		if err != nil {
-			return err, "Failed to generate the shared LTPA Keys file", ltpaSecretName
-		}
-	} else {
-		err := r.deleteLTPAKeysResources(instance)
-		if err != nil {
-			return err, "Failed to delete LTPA Keys Resource", ltpaSecretName
-		}
+const LTPA_RESOURCE_SHARING_FILE_NAME = "ltpa"
+
+func (r *ReconcileWebSphereLiberty) reconcileLTPAMetadata(instance *wlv1.WebSphereLibertyApplication, treeMap map[string]interface{}, latestOperandVersion string, assetsFolder *string) (*lutils.LTPAMetadata, error) {
+	metadata := &lutils.LTPAMetadata{}
+	// During runtime, the WebSphereLibertyApplication instance will decide what LTPA Secret to track by populating array pathChoices
+	pathOptions, pathChoices := r.getLTPAPathOptionsAndChoices(instance, latestOperandVersion)
+
+	// convert the path options and choices into a labelString, for a path of length n, the labelString is
+	// constructed as a weaved array in format "<pathOptions[0]>.<pathChoices[0]>.<pathOptions[1]>.<pathChoices[1]>...<pathOptions[n-1]>.<pathChoices[n-1]>"
+	labelString, err := tree.GetLabelFromDecisionPath(latestOperandVersion, pathOptions, pathChoices)
+	if err != nil {
+		return metadata, err
 	}
-	return nil, "", ltpaSecretName
+	// validate that the decision path such as "v1_4_0.managePasswordEncryption.<pathChoices[n-1]>" is a valid subpath in treeMap
+	// an error here indicates a build time error created by the operator developer or pollution of the ltpa-decision-tree.yaml
+	// Note: validSubPath is a substring of labelString and a valid path within treeMap; it will always hold that len(validSubPath) <= len(labelString)
+	validSubPath, err := tree.CanTraverseTree(treeMap, labelString, true)
+	if err != nil {
+		return metadata, err
+	}
+	// retrieve the LTPA leader tracker to re-use an existing name or to create a new metadata.Name
+	leaderTracker, _, err := lutils.GetLeaderTracker(instance, OperatorShortName, LTPA_RESOURCE_SHARING_FILE_NAME, r.GetClient())
+	if err != nil {
+		return metadata, err
+	}
+	// if the leaderTracker is on a mismatched version, wait for a subsequent reconcile loop to re-create the leader tracker
+	if leaderTracker.Labels[lutils.LeaderVersionLabel] != latestOperandVersion {
+		return metadata, fmt.Errorf("waiting for the Leader Tracker to be updated")
+	}
+
+	// to avoid limitation with Kubernetes label values having a max length of 63, translate validSubPath into a path index
+	pathIndex := tree.GetLeafIndex(treeMap, validSubPath)
+	versionedPathIndex := fmt.Sprintf("%s.%d", latestOperandVersion, pathIndex)
+
+	metadata.Path = validSubPath
+	metadata.PathIndex = versionedPathIndex
+	metadata.Name = r.getLTPAMetadataName(instance, leaderTracker, validSubPath, assetsFolder)
+	return metadata, nil
 }
 
-// Returns true if the WebsphereLibertyApplication instance initiated the LTPA keys sharing process or sets the instance as the leader if the LTPA keys are not yet shared
-func (r *ReconcileWebSphereLiberty) getLTPAKeysSharingLeader(instance *wlv1.WebSphereLibertyApplication, createServiceAccount bool) (error, string, bool, string) {
-	ltpaServiceAccount := &corev1.ServiceAccount{}
-	ltpaServiceAccount.Name = OperatorShortName + "-ltpa"
-	ltpaServiceAccount.Namespace = instance.GetNamespace()
-	ltpaServiceAccount.Labels = lutils.GetRequiredLabels(ltpaServiceAccount.Name, "")
-	err := r.GetClient().Get(context.TODO(), types.NamespacedName{Name: ltpaServiceAccount.Name, Namespace: ltpaServiceAccount.Namespace}, ltpaServiceAccount)
-	if err != nil {
-		if kerrors.IsNotFound(err) {
-			if createServiceAccount {
-				r.CreateOrUpdate(ltpaServiceAccount, instance, func() error {
-					return nil
-				})
-				return nil, instance.Name, true, ltpaServiceAccount.Name
+func (r *ReconcileWebSphereLiberty) getLTPAPathOptionsAndChoices(instance *wlv1.WebSphereLibertyApplication, latestOperandVersion string) ([]string, []string) {
+	var pathOptions, pathChoices []string
+	if latestOperandVersion == "v1_4_0" {
+		pathOptions = []string{"managePasswordEncryption"}                                                                                        // ordering matters, it must follow the nodes of the LTPA decision tree in ltpa-decision-tree.yaml
+		pathChoices = []string{strconv.FormatBool(r.isUsingPasswordEncryptionKeySharing(instance, &lutils.PasswordEncryptionMetadata{Name: ""}))} // fix LTPA to use the default password encryption key (no suffix)
+	}
+	// else if latestOperandVersion == "v1_4_1" {
+	// 	// for instance, say v1_4_1 introduces a new "type" variable with options "aes", "xor" or "hash"
+	// 	// The sequence must match .tree.v1_4_1.type.aes.managePasswordEncryption -> false located in the ltpa-decision-tree.yaml file
+	// 	// It is also possible that "type" is set to "xor" which will look like .tree.v1_4_1.type.xor.managePasswordEncryption -> false
+	// 	// Since CanTraverseTree checks for a subpath and ".tree.v1_4_1.type.xor" terminates at a leaf, .tree.v1_4_1.type.xor.managePasswordEncryption will pass validation
+	// 	pathOptions = []string{"type", "managePasswordEncryption"} // ordering matters, it must follow the nodes of the LTPA decision tree in ltpa-decision-tree.yaml
+	// 	pathChoices = []string{"aes", strconv.FormatBool(r.isPasswordEncryptionKeySharingEnabled(instance))}
+	// }
+	return pathOptions, pathChoices
+}
+
+func (r *ReconcileWebSphereLiberty) getLTPAMetadataName(instance *wlv1.WebSphereLibertyApplication, leaderTracker *corev1.Secret, validSubPath string, assetsFolder *string) string {
+	// if an existing resource name (suffix) for this key combination already exists, use it
+	loc := lutils.CommaSeparatedStringContains(string(leaderTracker.Data[lutils.ResourcePathsKey]), validSubPath)
+	if loc != -1 {
+		suffix, _ := lutils.GetCommaSeparatedString(string(leaderTracker.Data[lutils.ResourcesKey]), loc)
+		return suffix
+	}
+
+	// For example, if the env variable LTPA_RESOURCE_SUFFIXES is set,
+	// it can provide a comma separated string of length lutils.ResourceSuffixLength suffixes to exhaust
+	//
+	// spec:
+	//   env:
+	//     - name: LTPA_RESOURCE_SUFFIXES
+	//       value: "aaaaa,bbbbb,ccccc,zzzzz,a1b2c"
+	if predeterminedSuffixes, hasEnv := hasLTPAResourceSuffixesEnv(instance); hasEnv {
+		predeterminedSuffixesArray := lutils.GetCommaSeparatedArray(predeterminedSuffixes)
+		for _, suffix := range predeterminedSuffixesArray {
+			if len(suffix) == lutils.ResourceSuffixLength && lutils.IsLowerAlphanumericSuffix(suffix) && !strings.Contains(string(leaderTracker.Data[lutils.ResourcesKey]), suffix) {
+				return "-" + suffix
 			}
-			return nil, "", false, ""
 		}
-		return err, "", false, ltpaServiceAccount.Name
 	}
-	ltpaKeySharingLeaderName := ""
-	for _, ownerReference := range ltpaServiceAccount.OwnerReferences {
-		if ownerReference.Name == instance.Name {
-			return nil, instance.Name, true, ltpaServiceAccount.Name
+
+	// otherwise, generate a random suffix of length lutils.ResourceSuffixLength
+	randomSuffix := lutils.GetRandomLowerAlphanumericSuffix(lutils.ResourceSuffixLength)
+	suffixFoundInCluster := true // MUST check that the operator is not overriding another instance's untracked shared resource
+	for strings.Contains(string(leaderTracker.Data[lutils.ResourcesKey]), randomSuffix) || suffixFoundInCluster {
+		randomSuffix = lutils.GetRandomLowerAlphanumericSuffix(lutils.ResourceSuffixLength)
+		// create the unstructured object; parse and obtain the sharedResourceName via the internal/controller/assets/ltpa-signature.yaml
+		if sharedResource, sharedResourceName, err := lutils.CreateUnstructuredResourceFromSignature(LTPA_RESOURCE_SHARING_FILE_NAME, assetsFolder, OperatorShortName, randomSuffix); err == nil {
+			err := r.GetClient().Get(context.TODO(), types.NamespacedName{Namespace: instance.GetNamespace(), Name: sharedResourceName}, sharedResource)
+			if err != nil && kerrors.IsNotFound(err) {
+				suffixFoundInCluster = false
+			}
 		}
-		ltpaKeySharingLeaderName = ownerReference.Name
 	}
-	return nil, ltpaKeySharingLeaderName, false, ltpaServiceAccount.Name
+	return randomSuffix
+}
+
+func hasLTPAResourceSuffixesEnv(instance *wlv1.WebSphereLibertyApplication) (string, bool) {
+	for _, env := range instance.GetEnv() {
+		if env.Name == "LTPA_RESOURCE_SUFFIXES" {
+			return env.Value, true
+		}
+	}
+	return "", false
+}
+
+// Create or use an existing LTPA Secret identified by LTPA metadata for the WebSphereLibertyApplication instance
+func (r *ReconcileWebSphereLiberty) reconcileLTPAKeys(instance *wlv1.WebSphereLibertyApplication, ltpaMetadata *lutils.LTPAMetadata) (string, string, error) {
+	var err error
+	ltpaSecretName := ""
+	if r.isLTPAKeySharingEnabled(instance) {
+		ltpaSecretName, err = r.generateLTPAKeys(instance, ltpaMetadata)
+		if err != nil {
+			return "Failed to generate the shared LTPA keys Secret", ltpaSecretName, err
+		}
+	} else {
+		err := r.RemoveLeaderTrackerReference(instance, LTPA_RESOURCE_SHARING_FILE_NAME)
+		if err != nil {
+			return "Failed to remove leader tracking reference to the LTPA keys", ltpaSecretName, err
+		}
+	}
+	return "", ltpaSecretName, nil
 }
 
 // If the LTPA Secret is being created but does not exist yet, the LTPA instance leader will halt the process and restart creation of LTPA keys
-func (r *ReconcileWebSphereLiberty) restartLTPAKeysGeneration(instance *wlv1.WebSphereLibertyApplication) error {
-	err, _, isLTPAKeySharingLeader, _ := r.getLTPAKeysSharingLeader(instance, false)
+func (r *ReconcileWebSphereLiberty) restartLTPAKeysGeneration(instance *wlv1.WebSphereLibertyApplication, ltpaMetadata *lutils.LTPAMetadata) error {
+	_, thisInstanceIsLeader, _, err := r.reconcileLeader(instance, ltpaMetadata, LTPA_RESOURCE_SHARING_FILE_NAME, false)
 	if err != nil {
 		return err
 	}
-	if isLTPAKeySharingLeader {
+	if thisInstanceIsLeader {
 		ltpaSecret := &corev1.Secret{}
-		ltpaSecret.Name = OperatorShortName + "-managed-ltpa"
+		ltpaSecret.Name = OperatorShortName + "-managed-ltpa" + ltpaMetadata.Name
 		ltpaSecret.Namespace = instance.GetNamespace()
 		err = r.GetClient().Get(context.TODO(), types.NamespacedName{Name: ltpaSecret.Name, Namespace: ltpaSecret.Namespace}, ltpaSecret)
 		if err != nil && kerrors.IsNotFound(err) {
-			// Deleting the job request removes existing LTPA resourxes and restarts the LTPA generation process
+			// Deleting the job request removes existing LTPA resources and restarts the LTPA generation process
 			ltpaJobRequest := &corev1.ConfigMap{}
-			ltpaJobRequest.Name = OperatorShortName + "-managed-ltpa-job-request"
+			ltpaJobRequest.Name = OperatorShortName + "-managed-ltpa-job-request" + ltpaMetadata.Name
 			ltpaJobRequest.Namespace = instance.GetNamespace()
 			err = r.DeleteResource(ltpaJobRequest)
+			if err != nil {
+				return err
+			}
+
+			ltpaServiceAccount := &corev1.ServiceAccount{}
+			ltpaServiceAccountRootName := OperatorShortName + "-ltpa"
+			ltpaServiceAccount.Name = ltpaServiceAccountRootName + ltpaMetadata.Name
+			err = r.DeleteResource(ltpaServiceAccount)
 			if err != nil {
 				return err
 			}
@@ -108,44 +194,94 @@ func (r *ReconcileWebSphereLiberty) restartLTPAKeysGeneration(instance *wlv1.Web
 }
 
 // Generates the LTPA keys file and returns the name of the Secret storing its metadata
-func (r *ReconcileWebSphereLiberty) generateLTPAKeys(instance *wlv1.WebSphereLibertyApplication) (error, string) {
+func (r *ReconcileWebSphereLiberty) generateLTPAKeys(instance *wlv1.WebSphereLibertyApplication, ltpaMetadata *lutils.LTPAMetadata) (string, error) {
 	// Initialize LTPA resources
+	passwordEncryptionMetadata := &lutils.PasswordEncryptionMetadata{Name: ""}
+
 	ltpaXMLSecret := &corev1.Secret{}
-	ltpaXMLSecret.Name = OperatorShortName + lutils.LTPAServerXMLSuffix
+	ltpaXMLSecretRootName := OperatorShortName + lutils.LTPAServerXMLSuffix
+	ltpaXMLSecret.Name = ltpaXMLSecretRootName + ltpaMetadata.Name
 	ltpaXMLSecret.Namespace = instance.GetNamespace()
-	ltpaXMLSecret.Labels = lutils.GetRequiredLabels(ltpaXMLSecret.Name, "")
+	ltpaXMLSecret.Labels = lutils.GetRequiredLabels(ltpaXMLSecretRootName, ltpaXMLSecret.Name)
+
+	ltpaXMLMountSecret := &corev1.Secret{}
+	ltpaXMLMountSecretRootName := OperatorShortName + lutils.LTPAServerXMLMountSuffix
+	ltpaXMLMountSecret.Name = ltpaXMLMountSecretRootName + ltpaMetadata.Name
+	ltpaXMLMountSecret.Namespace = instance.GetNamespace()
+	ltpaXMLMountSecret.Labels = lutils.GetRequiredLabels(ltpaXMLMountSecretRootName, ltpaXMLSecret.Name)
 
 	generateLTPAKeysJob := &v1.Job{}
-	generateLTPAKeysJob.Name = OperatorShortName + "-managed-ltpa-keys-generation"
+	generateLTPAKeysJobRootName := OperatorShortName + "-managed-ltpa-keys-generation"
+	generateLTPAKeysJob.Name = generateLTPAKeysJobRootName + ltpaMetadata.Name
 	generateLTPAKeysJob.Namespace = instance.GetNamespace()
-	generateLTPAKeysJob.Labels = lutils.GetRequiredLabels(generateLTPAKeysJob.Name, "")
+	generateLTPAKeysJob.Labels = lutils.GetRequiredLabels(generateLTPAKeysJobRootName, generateLTPAKeysJob.Name)
 
 	deletePropagationBackground := metav1.DeletePropagationBackground
 
 	ltpaJobRequest := &corev1.ConfigMap{}
-	ltpaJobRequest.Name = OperatorShortName + "-managed-ltpa-job-request"
+	ltpaJobRequestRootName := OperatorShortName + "-managed-ltpa-job-request"
+	ltpaJobRequest.Name = ltpaJobRequestRootName + ltpaMetadata.Name
 	ltpaJobRequest.Namespace = instance.GetNamespace()
-	ltpaJobRequest.Labels = lutils.GetRequiredLabels(ltpaJobRequest.Name, "")
+	ltpaJobRequest.Labels = lutils.GetRequiredLabels(ltpaJobRequestRootName, ltpaJobRequest.Name)
 
 	ltpaKeysCreationScriptConfigMap := &corev1.ConfigMap{}
-	ltpaKeysCreationScriptConfigMap.Name = OperatorShortName + "-managed-ltpa-script"
+	ltpaKeysCreationScriptConfigMapRootName := OperatorShortName + "-managed-ltpa-script"
+	ltpaKeysCreationScriptConfigMap.Name = ltpaKeysCreationScriptConfigMapRootName + ltpaMetadata.Name
 	ltpaKeysCreationScriptConfigMap.Namespace = instance.GetNamespace()
-	ltpaKeysCreationScriptConfigMap.Labels = lutils.GetRequiredLabels(ltpaKeysCreationScriptConfigMap.Name, "")
+	ltpaKeysCreationScriptConfigMap.Labels = lutils.GetRequiredLabels(ltpaKeysCreationScriptConfigMapRootName, ltpaKeysCreationScriptConfigMap.Name)
+
+	ltpaServiceAccount := &corev1.ServiceAccount{}
+	ltpaServiceAccountRootName := OperatorShortName + "-ltpa"
+	ltpaServiceAccount.Name = ltpaServiceAccountRootName + ltpaMetadata.Name
+	ltpaServiceAccount.Namespace = instance.GetNamespace()
+	ltpaServiceAccount.Labels = lutils.GetRequiredLabels(ltpaServiceAccountRootName, ltpaServiceAccount.Name)
+
+	ltpaRole := &rbacv1.Role{}
+	ltpaRoleRootName := OperatorShortName + "-ltpa-role"
+	ltpaRole.Name = ltpaRoleRootName + ltpaMetadata.Name
+	ltpaRole.Namespace = instance.GetNamespace()
+	ltpaRole.Labels = lutils.GetRequiredLabels(ltpaRoleRootName, ltpaRole.Name)
+	ltpaRole.Rules = []rbacv1.PolicyRule{
+		{
+			Verbs:     []string{"create", "get"},
+			APIGroups: []string{""},
+			Resources: []string{"secrets"},
+		},
+	}
+
+	ltpaRoleBinding := &rbacv1.RoleBinding{}
+	ltpaRoleBindingRootName := OperatorShortName + "-ltpa-rolebinding"
+	ltpaRoleBinding.Name = ltpaRoleBindingRootName + ltpaMetadata.Name
+	ltpaRoleBinding.Namespace = instance.GetNamespace()
+	ltpaRoleBinding.Labels = lutils.GetRequiredLabels(ltpaRoleBindingRootName, ltpaRoleBinding.Name)
+	ltpaRoleBinding.Subjects = []rbacv1.Subject{
+		{
+			Kind:      "ServiceAccount",
+			Name:      ltpaServiceAccount.Name,
+			Namespace: instance.GetNamespace(),
+		},
+	}
+	ltpaRoleBinding.RoleRef = rbacv1.RoleRef{
+		APIGroup: "rbac.authorization.k8s.io",
+		Kind:     "Role",
+		Name:     ltpaRole.Name,
+	}
 
 	ltpaSecret := &corev1.Secret{}
-	ltpaSecret.Name = OperatorShortName + "-managed-ltpa"
+	ltpaSecretRootName := OperatorShortName + "-managed-ltpa"
+	ltpaSecret.Name = ltpaSecretRootName + ltpaMetadata.Name
 	ltpaSecret.Namespace = instance.GetNamespace()
-	ltpaSecret.Labels = lutils.GetRequiredLabels(ltpaSecret.Name, "")
+	ltpaSecret.Labels = lutils.GetRequiredLabels(ltpaSecretRootName, ltpaSecret.Name)
 	// If the LTPA Secret does not exist, run the Kubernetes Job to generate the shared ltpa.keys file and Secret
 	err := r.GetClient().Get(context.TODO(), types.NamespacedName{Name: ltpaSecret.Name, Namespace: ltpaSecret.Namespace}, ltpaSecret)
 	if err != nil && kerrors.IsNotFound(err) {
-		err, ltpaKeySharingLeaderName, isLTPAKeySharingLeader, ltpaServiceAccountName := r.getLTPAKeysSharingLeader(instance, true)
+		leaderName, thisInstanceIsLeader, _, err := r.reconcileLeader(instance, ltpaMetadata, LTPA_RESOURCE_SHARING_FILE_NAME, true)
 		if err != nil {
-			return err, ""
+			return "", err
 		}
 		// If this instance is not the leader, exit the reconcile loop
-		if !isLTPAKeySharingLeader {
-			return fmt.Errorf("Waiting for WebSphereLibertyApplication instance '" + ltpaKeySharingLeaderName + "' to generate the shared LTPA keys file for the namespace '" + instance.Namespace + "'."), ""
+		if !thisInstanceIsLeader {
+			return "", fmt.Errorf("Waiting for WebSphereLibertyApplication instance '" + leaderName + "' to generate the shared LTPA keys file for the namespace '" + instance.Namespace + "'.")
 		}
 
 		err = r.GetClient().Get(context.TODO(), types.NamespacedName{Name: ltpaJobRequest.Name, Namespace: ltpaJobRequest.Namespace}, ltpaJobRequest)
@@ -155,72 +291,62 @@ func (r *ReconcileWebSphereLiberty) generateLTPAKeys(instance *wlv1.WebSphereLib
 				// Clear all LTPA-related resources from a prior reconcile
 				err = r.DeleteResource(ltpaXMLSecret)
 				if err != nil {
-					return err, ""
+					return "", err
+				}
+				err = r.DeleteResource(ltpaXMLMountSecret)
+				if err != nil {
+					return "", err
 				}
 				err = r.DeleteResource(ltpaKeysCreationScriptConfigMap)
 				if err != nil {
-					return err, ""
+					return "", err
 				}
 				err = r.GetClient().Delete(context.TODO(), generateLTPAKeysJob, &client.DeleteOptions{PropagationPolicy: &deletePropagationBackground})
 				if err != nil && !kerrors.IsNotFound(err) {
-					return err, ""
+					return "", err
 				}
-				err := r.CreateOrUpdate(ltpaJobRequest, instance, func() error {
+				err := r.CreateOrUpdate(ltpaJobRequest, nil, func() error {
 					return nil
 				})
 				if err != nil {
-					return fmt.Errorf("Failed to create ConfigMap " + ltpaJobRequest.Name), ""
+					return "", fmt.Errorf("Failed to create ConfigMap " + ltpaJobRequest.Name)
 				}
 			} else {
-				return fmt.Errorf("Failed to get ConfigMap " + ltpaJobRequest.Name), ""
+				return "", fmt.Errorf("Failed to get ConfigMap " + ltpaJobRequest.Name)
 			}
 		} else {
-			// Create the Role/RoleBinding
-			ltpaRole := &rbacv1.Role{}
-			ltpaRole.Name = OperatorShortName + "-managed-ltpa-role"
-			ltpaRole.Namespace = instance.GetNamespace()
-			ltpaRole.Rules = []rbacv1.PolicyRule{
-				{
-					Verbs:     []string{"create", "get"},
-					APIGroups: []string{""},
-					Resources: []string{"secrets"},
-				},
-			}
-			ltpaRole.Labels = lutils.GetRequiredLabels(ltpaRole.Name, "")
-			r.CreateOrUpdate(ltpaRole, instance, func() error {
+			// Create the ServiceAccount
+			if err := r.CreateOrUpdate(ltpaServiceAccount, nil, func() error {
 				return nil
-			})
+			}); err != nil && !kerrors.IsNotFound(err) {
+				return "", fmt.Errorf("Failed to create ServiceAccount " + ltpaServiceAccount.Name)
+			}
 
-			ltpaRoleBinding := &rbacv1.RoleBinding{}
-			ltpaRoleBinding.Name = OperatorShortName + "-managed-ltpa-rolebinding"
-			ltpaRoleBinding.Namespace = instance.GetNamespace()
-			ltpaRoleBinding.Subjects = []rbacv1.Subject{
-				{
-					Kind:      "ServiceAccount",
-					Name:      ltpaServiceAccountName,
-					Namespace: instance.GetNamespace(),
-				},
-			}
-			ltpaRoleBinding.RoleRef = rbacv1.RoleRef{
-				APIGroup: "rbac.authorization.k8s.io",
-				Kind:     "Role",
-				Name:     ltpaRole.Name,
-			}
-			ltpaRoleBinding.Labels = lutils.GetRequiredLabels(ltpaRoleBinding.Name, "")
-			r.CreateOrUpdate(ltpaRoleBinding, instance, func() error {
+			// Create the Role/RoleBinding
+			if err := r.CreateOrUpdate(ltpaRole, nil, func() error {
 				return nil
-			})
+			}); err != nil && !kerrors.IsNotFound(err) {
+				return "", fmt.Errorf("Failed to create Role " + ltpaRole.Name)
+			}
+			if err := r.CreateOrUpdate(ltpaRoleBinding, nil, func() error {
+				return nil
+			}); err != nil && !kerrors.IsNotFound(err) {
+				return "", fmt.Errorf("Failed to create RoleBinding " + ltpaRoleBinding.Name)
+			}
 
 			// Create a ConfigMap to store the internal/controller/assets/create_ltpa_keys.sh script
 			err = r.GetClient().Get(context.TODO(), types.NamespacedName{Name: ltpaKeysCreationScriptConfigMap.Name, Namespace: ltpaKeysCreationScriptConfigMap.Namespace}, ltpaKeysCreationScriptConfigMap)
 			if err != nil && kerrors.IsNotFound(err) {
 				ltpaKeysCreationScriptConfigMap.Data = make(map[string]string)
-				script, err := ioutil.ReadFile("internal/controller/assets/create_ltpa_keys.sh")
+				script, err := os.ReadFile("internal/controller/assets/" + lutils.LTPAKeysCreationScriptFileName)
 				if err != nil {
-					return err, ""
+					return "", err
 				}
-				ltpaKeysCreationScriptConfigMap.Data["create_ltpa_keys.sh"] = string(script)
-				r.CreateOrUpdate(ltpaKeysCreationScriptConfigMap, instance, func() error {
+				ltpaKeysCreationScriptConfigMap.Data[lutils.LTPAKeysCreationScriptFileName] = string(script)
+				// prevent script from being modified
+				trueBool := true
+				ltpaKeysCreationScriptConfigMap.Immutable = &trueBool
+				r.CreateOrUpdate(ltpaKeysCreationScriptConfigMap, nil, func() error {
 					return nil
 				})
 			}
@@ -228,28 +354,59 @@ func (r *ReconcileWebSphereLiberty) generateLTPAKeys(instance *wlv1.WebSphereLib
 			// Verify the internal/controller/assets/create_ltpa_keys.sh script has been loaded before starting the LTPA Job
 			err = r.GetClient().Get(context.TODO(), types.NamespacedName{Name: ltpaKeysCreationScriptConfigMap.Name, Namespace: ltpaKeysCreationScriptConfigMap.Namespace}, ltpaKeysCreationScriptConfigMap)
 			if err == nil {
+				// Compare the bundle script against the ltpaKeysCreationScriptConfigMap's saved script
+				script, err := os.ReadFile("internal/controller/assets/" + lutils.LTPAKeysCreationScriptFileName)
+				if err != nil {
+					return "", err
+				}
+				savedScript, found := ltpaKeysCreationScriptConfigMap.Data[lutils.LTPAKeysCreationScriptFileName]
+				// Delete ltpaKeysCreationScriptConfigMap if it is missing the data key
+				if !found {
+					if err := r.DeleteResource(ltpaKeysCreationScriptConfigMap); err != nil {
+						return "", err
+					}
+					return "", fmt.Errorf("the LTPA Keys Creation ConfigMap is missing key " + lutils.LTPAKeysCreationScriptFileName)
+				}
+				// Delete ltpaKeysCreationScriptConfigMap if the file contents do not match
+				if string(script) != savedScript {
+					if err := r.DeleteResource(ltpaKeysCreationScriptConfigMap); err != nil {
+						return "", err
+					}
+					return "", fmt.Errorf("the LTPA Keys Creation ConfigMap key '" + lutils.LTPAKeysCreationScriptFileName + "' is out of sync")
+				}
 				// Run the Kubernetes Job to generate the shared ltpa.keys file and LTPA Secret
 				err = r.GetClient().Get(context.TODO(), types.NamespacedName{Name: generateLTPAKeysJob.Name, Namespace: generateLTPAKeysJob.Namespace}, generateLTPAKeysJob)
 				if err != nil && kerrors.IsNotFound(err) {
-					err = r.CreateOrUpdate(generateLTPAKeysJob, instance, func() error {
-						lutils.CustomizeLTPAJob(generateLTPAKeysJob, instance, ltpaSecret.Name, ltpaServiceAccountName, ltpaKeysCreationScriptConfigMap.Name, ltpaJobRequest.Name)
+					err = r.CreateOrUpdate(generateLTPAKeysJob, nil, func() error {
+						ltpaConfig := &lutils.LTPAConfig{
+							Metadata:                    ltpaMetadata,
+							SecretName:                  ltpaSecretRootName,
+							SecretInstanceName:          ltpaSecret.Name,
+							ServiceAccountName:          ltpaServiceAccount.Name,
+							ConfigMapName:               ltpaKeysCreationScriptConfigMap.Name,
+							JobRequestConfigMapName:     ltpaJobRequest.Name,
+							FileName:                    lutils.LTPAKeysFileName,
+							EncryptionKeySecretName:     lutils.PasswordEncryptionKeyRootName + passwordEncryptionMetadata.Name + "-internal",
+							EncryptionKeySharingEnabled: r.isUsingPasswordEncryptionKeySharing(instance, passwordEncryptionMetadata), // fix LTPA to use the default password encryption key (no suffix)
+						}
+						lutils.CustomizeLTPAJob(generateLTPAKeysJob, instance, ltpaConfig, r.GetClient())
 						return nil
 					})
 					if err != nil {
-						return fmt.Errorf("Failed to create Job " + generateLTPAKeysJob.Name), ""
+						return "", fmt.Errorf("Failed to create Job %s: %s"+generateLTPAKeysJob.Name, err)
 					}
 				} else if err == nil {
 					// If the LTPA Secret is not yet created (LTPA Job has not successfully completed)
 					// and the LTPA Job's configuration is outdated, retry LTPA generation with the new configuration
-					if lutils.IsLTPAJobConfigurationOutdated(generateLTPAKeysJob, instance) {
+					if lutils.IsLTPAJobConfigurationOutdated(generateLTPAKeysJob, instance, r.GetClient()) {
 						// Delete the Job request to restart the entire LTPA generation process (i.e. reloading the script, ltpa.xml, and Job)
 						err = r.DeleteResource(ltpaJobRequest)
 						if err != nil {
-							return err, ltpaSecret.Name
+							return ltpaSecret.Name, err
 						}
 					}
 				} else {
-					return fmt.Errorf("Failed to get Job " + generateLTPAKeysJob.Name), ""
+					return "", fmt.Errorf("Failed to get Job " + generateLTPAKeysJob.Name)
 				}
 			}
 		}
@@ -257,41 +414,93 @@ func (r *ReconcileWebSphereLiberty) generateLTPAKeys(instance *wlv1.WebSphereLib
 		// Reconcile the Job
 		err = r.GetClient().Get(context.TODO(), types.NamespacedName{Name: generateLTPAKeysJob.Name, Namespace: generateLTPAKeysJob.Namespace}, generateLTPAKeysJob)
 		if err != nil && kerrors.IsNotFound(err) {
-			return fmt.Errorf("Waiting for the LTPA key to be generated by Job '" + generateLTPAKeysJob.Name + "'."), ""
+			return "", fmt.Errorf("Waiting for the LTPA key to be generated by Job '" + generateLTPAKeysJob.Name + "'.")
 		} else if err != nil {
-			return fmt.Errorf("Failed to get Job " + generateLTPAKeysJob.Name), ""
+			return "", fmt.Errorf("Failed to get Job " + generateLTPAKeysJob.Name)
 		}
 		if len(generateLTPAKeysJob.Status.Conditions) > 0 && generateLTPAKeysJob.Status.Conditions[0].Type == v1.JobFailed {
-			return fmt.Errorf("Job " + generateLTPAKeysJob.Name + " has failed. Manually clean up hung resources by setting .spec.manageLTPA to false in the " + ltpaKeySharingLeaderName + " instance."), ""
+			return "", fmt.Errorf("Job " + generateLTPAKeysJob.Name + " has failed. Manually clean up hung resources by setting .spec.manageLTPA to false in the " + leaderName + " instance.")
 		}
-		return fmt.Errorf("Waiting for the LTPA key to be generated by Job '" + generateLTPAKeysJob.Name + "'."), ""
+		return "", fmt.Errorf("Waiting for the LTPA key to be generated by Job '" + generateLTPAKeysJob.Name + "'.")
 	} else if err != nil {
-		return err, ""
+		return "", err
 	} else {
-		err, _, isLTPAKeySharingLeader, _ := r.getLTPAKeysSharingLeader(instance, false)
+		_, thisInstanceIsLeader, _, err := r.reconcileLeader(instance, ltpaMetadata, LTPA_RESOURCE_SHARING_FILE_NAME, true)
 		if err != nil {
-			return err, ""
+			return "", err
 		}
-		if !isLTPAKeySharingLeader {
-			return nil, ltpaSecret.Name
+		if !thisInstanceIsLeader {
+			return ltpaSecret.Name, nil
 		}
 	}
 
-	// The LTPA Secret is created (in other words, the LTPA Job has completed), so delete the Job request
+	// The LTPA Secret is created (in other words, the LTPA Job has completed) so delete the Job request
 	err = r.DeleteResource(ltpaJobRequest)
 	if err != nil {
-		return err, ltpaSecret.Name
+		return ltpaSecret.Name, err
+	}
+	// The LTPA Secret is created so delete the ServiceAccount, Role and RoleBinding
+	err = r.DeleteResource(ltpaServiceAccount)
+	if err != nil {
+		return ltpaSecret.Name, err
+	}
+	err = r.DeleteResource(ltpaRole)
+	if err != nil {
+		return ltpaSecret.Name, err
+	}
+	err = r.DeleteResource(ltpaRoleBinding)
+	if err != nil {
+		return ltpaSecret.Name, err
 	}
 
-	// Create the Liberty Server XML Secret if it doesn't exist
-	serverXMLSecretErr := r.GetClient().Get(context.TODO(), types.NamespacedName{Name: ltpaXMLSecret.Name, Namespace: ltpaXMLSecret.Namespace}, ltpaXMLSecret)
-	if serverXMLSecretErr != nil && kerrors.IsNotFound(serverXMLSecretErr) {
-		r.CreateOrUpdate(ltpaXMLSecret, nil, func() error {
-			lutils.CustomizeLTPAServerXML(ltpaXMLSecret, instance, string(ltpaSecret.Data["password"]))
-			return nil
-		})
+	// Create/update the Secret to hold the server.xml that will import the LTPA keys into the Liberty server
+	// This server.xml will be mounted in /config/configDropins/overrides/ltpaKeysMount.xml
+	serverXMLMountSecretErr := r.GetClient().Get(context.TODO(), types.NamespacedName{Name: ltpaXMLMountSecret.Name, Namespace: ltpaXMLMountSecret.Namespace}, ltpaXMLMountSecret)
+	if serverXMLMountSecretErr != nil && !kerrors.IsNotFound(serverXMLMountSecretErr) {
+		return "", serverXMLMountSecretErr
 	}
-	return nil, ltpaSecret.Name
+	if err := r.CreateOrUpdate(ltpaXMLMountSecret, nil, func() error {
+		mountDir := strings.Replace(lutils.SecureMountPath+"/"+lutils.LTPAKeysXMLFileName, "/output", "${server.output.dir}", 1)
+		return lutils.CustomizeLibertyFileMountXML(ltpaXMLMountSecret, lutils.LTPAKeysMountXMLFileName, mountDir)
+	}); err != nil {
+		return "", err
+	}
+
+	// Create/update the Liberty Server XML Secret
+	serverXMLSecretErr := r.GetClient().Get(context.TODO(), types.NamespacedName{Name: ltpaXMLSecret.Name, Namespace: ltpaXMLSecret.Namespace}, ltpaXMLSecret)
+	if serverXMLSecretErr != nil && !kerrors.IsNotFound(serverXMLSecretErr) {
+		return "", serverXMLSecretErr
+	}
+	// NOTE: Update is important here for compatibility with an operator upgrade from version 1,3,3 that did not use ltpaXMLMountSecret
+	if err := r.CreateOrUpdate(ltpaXMLSecret, nil, func() error {
+		return lutils.CustomizeLTPAServerXML(ltpaXMLSecret, instance, string(ltpaSecret.Data["password"]))
+	}); err != nil {
+		return "", err
+	}
+
+	// Validate whether or not password encryption settings match the way LTPA keys were created
+	hasConfigurationMismatch := false
+	ltpaEncryptionLR, ltpaEncryptionLRFound := ltpaSecret.Data["encryptionSecretLastRotation"]
+	if r.isPasswordEncryptionKeySharingEnabled(instance) {
+		if encryptionKeySecret, err := r.hasInternalEncryptionKeySecret(instance, passwordEncryptionMetadata); err == nil {
+			if !ltpaEncryptionLRFound || string(ltpaEncryptionLR) != string(encryptionKeySecret.Data["lastRotation"]) {
+				hasConfigurationMismatch = true // managePasswordEncryption is true, the shared encryption key exists but LTPA keys are either not encrypted or not updated
+			}
+		} else if kerrors.IsNotFound(err) && ltpaEncryptionLRFound {
+			hasConfigurationMismatch = true // managePasswordEncryption is true, the shared encryption key is missing but LTPA keys are still encrypted
+		}
+	} else if ltpaEncryptionLRFound {
+		hasConfigurationMismatch = true // managePasswordEncryption is false but LTPA keys are encrypted
+	}
+
+	// Delete the LTPA Secret and depend on the create_ltpa_keys.sh script to add/remove/update the lastRotation field
+	if hasConfigurationMismatch {
+		err = r.DeleteResource(ltpaSecret)
+		if err != nil {
+			return "", err
+		}
+	}
+	return ltpaSecret.Name, nil
 }
 
 func (r *ReconcileWebSphereLiberty) isLTPAKeySharingEnabled(instance *wlv1.WebSphereLibertyApplication) bool {
@@ -301,65 +510,89 @@ func (r *ReconcileWebSphereLiberty) isLTPAKeySharingEnabled(instance *wlv1.WebSp
 	return false
 }
 
-// Deletes resources used to create the LTPA keys file
-func (r *ReconcileWebSphereLiberty) deleteLTPAKeysResources(instance *wlv1.WebSphereLibertyApplication) error {
-	// Don't delete LTPA keys resources if this instance is not the leader
-	err, _, isLTPAKeySharingLeader, ltpaServiceAccountName := r.getLTPAKeysSharingLeader(instance, false)
+// Search the cluster namespace for existing LTPA Secrets
+func (r *ReconcileWebSphereLiberty) GetLTPAResources(instance *wlv1.WebSphereLibertyApplication, treeMap map[string]interface{}, replaceMap map[string]map[string]string, latestOperandVersion string, assetsFolder *string) (*unstructured.UnstructuredList, string, error) {
+	ltpaResourceList, err := lutils.CreateUnstructuredResourceListFromSignature(LTPA_RESOURCE_SHARING_FILE_NAME, assetsFolder, OperatorShortName)
 	if err != nil {
-		return err
+		return nil, "", err
 	}
-	if !isLTPAKeySharingLeader {
-		return nil
-	}
-
-	generateLTPAKeysJob := &v1.Job{}
-	generateLTPAKeysJob.Name = OperatorShortName + "-managed-ltpa-keys-generation"
-	generateLTPAKeysJob.Namespace = instance.GetNamespace()
-	deletePropagationBackground := metav1.DeletePropagationBackground
-	err = r.GetClient().Delete(context.TODO(), generateLTPAKeysJob, &client.DeleteOptions{PropagationPolicy: &deletePropagationBackground})
-	if err != nil && !kerrors.IsNotFound(err) {
-		return err
+	ltpaRootName := OperatorShortName + "-managed-ltpa"
+	if err := r.GetClient().List(context.TODO(), ltpaResourceList, client.MatchingLabels{
+		"app.kubernetes.io/name": ltpaRootName,
+	}, client.InNamespace(instance.GetNamespace())); err != nil {
+		return nil, "", err
 	}
 
-	ltpaKeysCreationScriptConfigMap := &corev1.ConfigMap{}
-	ltpaKeysCreationScriptConfigMap.Name = OperatorShortName + "-managed-ltpa-script"
-	ltpaKeysCreationScriptConfigMap.Namespace = instance.GetNamespace()
-	err = r.DeleteResource(ltpaKeysCreationScriptConfigMap)
-	if err != nil {
-		return err
-	}
+	// If "wlo-managed-ltpa" exists and there is no collision, patch the wlo-managed-ltpa with a leader tracking label to work on the current resource tracking impl.
+	if defaultLTPAKeyIndex := defaultLTPAKeyExists(ltpaResourceList, ltpaRootName); defaultLTPAKeyIndex != -1 {
+		defaultUpdatedPathIndex := ""
+		// the "wlo-managed-ltpa" would only exist on 1.3.3, so the path is hardcoded to start replaceMap translation at "v1_3_3.default"
+		if path, err := tree.ReplacePath("v1_3_3.default", latestOperandVersion, treeMap, replaceMap); err == nil {
+			defaultUpdatedPathIndex = strings.Split(path, ".")[0] + "." + strconv.FormatInt(int64(tree.GetLeafIndex(treeMap, path)), 10)
+		}
+		// to prevent collisions, for each LTPA key, check that the default LTPA key does not already exist
+		if defaultUpdatedPathIndex != "" {
+			defaultKeyAlreadyExists := false
+			for _, resource := range ltpaResourceList.Items {
+				if resource.GetName() != ltpaRootName {
+					labelsMap, _, err := unstructured.NestedMap(resource.Object, "metadata", "labels")
+					if err != nil {
+						return nil, "", err
+					}
+					if pathIndexInterface, found := labelsMap[lutils.ResourcePathIndexLabel]; found {
+						pathIndex := pathIndexInterface.(string)
+						// Skip this resource if path index does not contain a period separating delimeter
+						if !strings.Contains(pathIndex, ".") {
+							continue
+						}
+						labelVersionArray := strings.Split(pathIndex, ".")
+						// Skip this resource if the path index is not a tuple representing the version and index
+						if len(labelVersionArray) != 2 {
+							continue
+						}
+						indexIntVal, _ := strconv.ParseInt(labelVersionArray[1], 10, 64)
+						path, pathErr := tree.GetPathFromLeafIndex(treeMap, labelVersionArray[0], int(indexIntVal))
+						if pathErr == nil && labelVersionArray[0] != latestOperandVersion {
+							if path, err := tree.ReplacePath(path, latestOperandVersion, treeMap, replaceMap); err == nil {
+								updatedPathIndex := strings.Split(path, ".")[0] + "." + strconv.FormatInt(int64(tree.GetLeafIndex(treeMap, path)), 10)
+								if defaultUpdatedPathIndex == updatedPathIndex {
+									defaultKeyAlreadyExists = true
+									break
+								}
+							}
+						}
 
-	ltpaJobRequest := &corev1.ConfigMap{}
-	ltpaJobRequest.Name = OperatorShortName + "-managed-ltpa-job-request"
-	ltpaJobRequest.Namespace = instance.GetNamespace()
-	err = r.DeleteResource(ltpaJobRequest)
-	if err != nil {
-		return err
-	}
+					}
+				}
+			}
+			// it was determined that no collisions for the default key exists, so "wlo-managed-ltpa" can be reused in this operator
+			if !defaultKeyAlreadyExists {
+				if err := r.CreateOrUpdate(&ltpaResourceList.Items[defaultLTPAKeyIndex], nil, func() error {
+					// add the ResourcePathIndexLabel which does not exist in 1,3,3
+					labelsMap, _, err := unstructured.NestedMap(ltpaResourceList.Items[defaultLTPAKeyIndex].Object, "metadata", "labels")
+					if err != nil {
+						return err
+					}
+					labelsMap[lutils.ResourcePathIndexLabel] = defaultUpdatedPathIndex
+					if err := unstructured.SetNestedMap(ltpaResourceList.Items[defaultLTPAKeyIndex].Object, labelsMap, "metadata", "labels"); err != nil {
+						return err
+					}
+					return nil
+				}); err != nil {
+					return nil, "", err
+				}
 
-	ltpaRoleBinding := &rbacv1.RoleBinding{}
-	ltpaRoleBinding.Name = OperatorShortName + "-managed-ltpa-rolebinding"
-	ltpaRoleBinding.Namespace = instance.GetNamespace()
-	err = r.DeleteResource(ltpaRoleBinding)
-	if err != nil {
-		return err
+			}
+		}
 	}
+	return ltpaResourceList, ltpaRootName, nil
+}
 
-	ltpaRole := &rbacv1.Role{}
-	ltpaRole.Name = OperatorShortName + "-managed-ltpa-role"
-	ltpaRole.Namespace = instance.GetNamespace()
-	err = r.DeleteResource(ltpaRole)
-	if err != nil {
-		return err
+func defaultLTPAKeyExists(ltpaResourceList *unstructured.UnstructuredList, defaultKeyName string) int {
+	for i, resource := range ltpaResourceList.Items {
+		if resource.GetName() == defaultKeyName {
+			return i
+		}
 	}
-
-	ltpaServiceAccount := &corev1.ServiceAccount{}
-	ltpaServiceAccount.Name = ltpaServiceAccountName
-	ltpaServiceAccount.Namespace = instance.GetNamespace()
-	err = r.DeleteResource(ltpaServiceAccount)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return -1
 }

--- a/internal/controller/ltpa_keys_sharing_test.go
+++ b/internal/controller/ltpa_keys_sharing_test.go
@@ -1,0 +1,609 @@
+/*
+  Copyright contributors to the WASdev project.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	tree "github.com/OpenLiberty/open-liberty-operator/utils/tree"
+	wlv1 "github.com/WASdev/websphere-liberty-operator/api/v1"
+	lutils "github.com/WASdev/websphere-liberty-operator/utils"
+	oputils "github.com/application-stacks/runtime-component-operator/utils"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var (
+	name       = "app"
+	namespace  = "websphereliberty"
+	trueValue  = true
+	falseValue = false
+)
+
+type Test struct {
+	test     string
+	expected interface{}
+	actual   interface{}
+}
+
+func TestIsLTPAKeySharingEnabled(t *testing.T) {
+	logger := zap.New()
+	logf.SetLogger(logger)
+	os.Setenv("WATCH_NAMESPACE", namespace)
+
+	// Test default values no config
+	spec := wlv1.WebSphereLibertyApplicationSpec{}
+
+	// Create Liberty app
+	instance := createWebSphereLibertyApp(name, namespace, spec)
+	r := createReconcilerFromWebSphereLibertyApp(instance)
+
+	// test disabled by default
+	tests := []Test{
+		{"LTPA disabled when .spec.manageLTPA is nil", false, r.isLTPAKeySharingEnabled(instance)},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// enable LTPA
+	spec.ManageLTPA = &trueValue
+	instance = createWebSphereLibertyApp(name, namespace, spec)
+
+	// test enabled
+	tests = []Test{
+		{"LTPA enabled when .spec.manageLTPA is set to true", true, r.isLTPAKeySharingEnabled(instance)},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// disable LTPA
+	spec.ManageLTPA = &falseValue
+	instance = createWebSphereLibertyApp(name, namespace, spec)
+
+	// test disabled
+	tests = []Test{
+		{"LTPA disabled when .spec.manageLTPA is set to false", false, r.isLTPAKeySharingEnabled(instance)},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func getControllerFolder() string {
+	cwd, err := os.Getwd()
+	if err != nil || !strings.HasSuffix(cwd, "internal/controller") {
+		return "internal/controller"
+	}
+	return cwd
+}
+
+func getAssetsFolder() string {
+	return getControllerFolder() + "/assets"
+}
+
+func TestLTPALeaderTracker(t *testing.T) {
+	logger := zap.New()
+	logf.SetLogger(logger)
+	os.Setenv("WATCH_NAMESPACE", namespace)
+
+	// Test default values no config
+	spec := wlv1.WebSphereLibertyApplicationSpec{}
+
+	// Create Liberty app
+	instance := createWebSphereLibertyApp(name, namespace, spec)
+	r := createReconcilerFromWebSphereLibertyApp(instance)
+
+	// First, get the LTPA leader tracker which is not initialized
+	leaderTracker, _, err := lutils.GetLeaderTracker(instance, OperatorShortName, LTPA_RESOURCE_SHARING_FILE_NAME, r.GetClient())
+
+	emptyLeaderTracker := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "wlo-managed-leader-tracking-ltpa",
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/instance":   "wlo-managed-leader-tracking-ltpa",
+				"app.kubernetes.io/managed-by": "websphere-liberty-operator",
+				"app.kubernetes.io/name":       "wlo-managed-leader-tracking-ltpa",
+			},
+		},
+	}
+	tests := []Test{
+		{"get LTPA leader tracker is nil", emptyLeaderTracker, leaderTracker},
+		{"get LTPA leader tracker is not found", true, kerrors.IsNotFound(err)},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Second, initialize the LTPA leader tracker
+	latestOperandVersion := "v10_4_1"
+	fileName := getControllerFolder() + "/tests/ltpa-decision-tree-complex.yaml"
+	treeMap, replaceMap, err := tree.ParseDecisionTree(LTPA_RESOURCE_SHARING_FILE_NAME, &fileName)
+	tests = []Test{
+		{"parse decision tree complex", nil, err},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	assetsFolder := getAssetsFolder()
+	err = r.reconcileLeaderTracker(instance, treeMap, replaceMap, "v10_4_1", LTPA_RESOURCE_SHARING_FILE_NAME, &assetsFolder)
+	tests = []Test{
+		{"initialize LTPA leader tracker", nil, err},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	leaderTracker, _, err = lutils.GetLeaderTracker(instance, OperatorShortName, LTPA_RESOURCE_SHARING_FILE_NAME, r.GetClient())
+	expectedLeaderTrackerData := map[string][]byte{}
+	expectedLeaderTrackerData[lutils.ResourcesKey] = []byte("")
+	expectedLeaderTrackerData[lutils.ResourceOwnersKey] = []byte("")
+	expectedLeaderTrackerData[lutils.ResourcePathsKey] = []byte("")
+	expectedLeaderTrackerData[lutils.ResourcePathIndicesKey] = []byte("")
+	tests = []Test{
+		{"get LTPA leader tracker name", "wlo-managed-leader-tracking-ltpa", leaderTracker.Name},
+		{"get LTPA leader tracker namespace", namespace, leaderTracker.Namespace},
+		{"get LTPA leader tracker data", expectedLeaderTrackerData, leaderTracker.Data},
+		{"get LTPA leader tracker label", latestOperandVersion, leaderTracker.Labels[lutils.LeaderVersionLabel]},
+		{"get LTPA leader tracker error", nil, err},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Thirdly, create an LTPA Secret based upon a path in ltpa-decision-tree-complex.yaml
+	complexSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "wlo-managed-ltpa-ab215",
+			Namespace: namespace,
+			Labels: map[string]string{
+				lutils.ResourcePathIndexLabel: latestOperandVersion + ".2", // choosing path index 2 under tree v10_4_1 (i.e. v10_4_1.a.b.e.true)
+			},
+		},
+		Data: map[string][]byte{}, // create empty data
+	}
+
+	err1 := r.CreateOrUpdate(complexSecret, nil, func() error { return nil })
+	tests = []Test{
+		{"create LTPA Secret from based on path index 2 of complex decision tree", nil, err1},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Mock the process where the operator saves the LTPA Secret, storing it into the leader tracker
+	leaderName, isLeader, pathIndex, err := r.reconcileLeader(instance, &lutils.LTPAMetadata{
+		Path:      latestOperandVersion + ".a.b.e.true",
+		PathIndex: latestOperandVersion + ".2",
+		Name:      "-ab215",
+	}, LTPA_RESOURCE_SHARING_FILE_NAME, true)
+	tests = []Test{
+		{"update leader tracker based on path index 2 of complex decision tree - error", nil, err},
+		{"update leader tracker based on path index 2 of complex decision tree - path index", pathIndex, latestOperandVersion + ".2"},
+		{"update leader tracker based on path index 2 of complex decision tree - isLeader", true, isLeader},
+		{"update leader tracker based on path index 2 of complex decision tree - leader name", instance.Name, leaderName},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Fourth, check that the leader tracker received the new LTPA state
+	leaderTracker, leaderTrackers, err := lutils.GetLeaderTracker(instance, OperatorShortName, LTPA_RESOURCE_SHARING_FILE_NAME, r.GetClient())
+	expectedLeaderTrackerData = map[string][]byte{
+		lutils.ResourcesKey:           []byte("-ab215"),
+		lutils.ResourceOwnersKey:      []byte(name),
+		lutils.ResourcePathsKey:       []byte(latestOperandVersion + ".a.b.e.true"),
+		lutils.ResourcePathIndicesKey: []byte(latestOperandVersion + ".2"),
+	}
+	tests = []Test{
+		{"get LTPA leader tracker name", "wlo-managed-leader-tracking-ltpa", leaderTracker.Name},
+		{"get LTPA leader tracker namespace", namespace, leaderTracker.Namespace},
+		{"get LTPA leader tracker data", expectedLeaderTrackerData, leaderTracker.Data},
+		{"get LTPA leader tracker label", latestOperandVersion, leaderTracker.Labels[lutils.LeaderVersionLabel]},
+		{"get LTPA leader tracker error", nil, err},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Fifth, add another Secret
+	complexSecretTwo := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "wlo-managed-ltpa-cd123",
+			Namespace: namespace,
+			Labels: map[string]string{
+				lutils.ResourcePathIndexLabel: latestOperandVersion + ".1",
+			},
+		},
+		Data: map[string][]byte{}, // create empty data
+	}
+
+	err2 := r.CreateOrUpdate(complexSecretTwo, nil, func() error { return nil })
+	tests = []Test{
+		{"create LTPA Secret from based on path index 1 of complex decision tree", nil, err2},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Mock the process where the operator saves the LTPA Secret, storing it into the leader tracker
+	r.reconcileLeader(instance, &lutils.LTPAMetadata{
+		Path:      latestOperandVersion + ".a.b.d.true",
+		PathIndex: latestOperandVersion + ".1",
+		Name:      "-cd123",
+	}, LTPA_RESOURCE_SHARING_FILE_NAME, true)
+
+	// Sixth, check that the LTPA leader tracker was updated
+	leaderTracker, _, err = lutils.GetLeaderTracker(instance, OperatorShortName, LTPA_RESOURCE_SHARING_FILE_NAME, r.GetClient())
+	expectedLeaderTrackerData = map[string][]byte{
+		lutils.ResourcesKey:           []byte("-ab215,-cd123"),
+		lutils.ResourceOwnersKey:      []byte(fmt.Sprintf(",%s", instance.Name)), // The owner reference was removed for -ab215 and added for -cd123
+		lutils.ResourcePathsKey:       []byte(fmt.Sprintf("%s.a.b.e.true,%s.a.b.d.true", latestOperandVersion, latestOperandVersion)),
+		lutils.ResourcePathIndicesKey: []byte(fmt.Sprintf("%s.2,%s.1", latestOperandVersion, latestOperandVersion)),
+	}
+	tests = []Test{
+		{"get LTPA leader tracker name", "wlo-managed-leader-tracking-ltpa", leaderTracker.Name},
+		{"get LTPA leader tracker namespace", namespace, leaderTracker.Namespace},
+		{"get LTPA leader tracker data", expectedLeaderTrackerData, leaderTracker.Data},
+		{"get LTPA leader tracker label", latestOperandVersion, leaderTracker.Labels[lutils.LeaderVersionLabel]},
+		{"get LTPA leader tracker error", nil, err},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Lastly, remove the LTPA leader
+	err1 = r.RemoveLeaderTrackerReference(instance, LTPA_RESOURCE_SHARING_FILE_NAME)
+	err2 = r.RemoveLeader(instance, leaderTracker, leaderTrackers)
+	_, leaderTrackers, leaderTrackerErr := lutils.GetLeaderTracker(instance, OperatorShortName, LTPA_RESOURCE_SHARING_FILE_NAME, r.GetClient())
+	var nilLeaderTrackers *[]lutils.LeaderTracker
+	tests = []Test{
+		{"remove LTPA - deleteLTPAKeysResource errors", nil, err1},
+		{"remove LTPA - RemoveLeader errors", nil, err2},
+		{"remove LTPA - GetLeaderTracker is not found", true, kerrors.IsNotFound(leaderTrackerErr)},
+		{"remove LTPA - leader trackers list is nil", nilLeaderTrackers, leaderTrackers},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+// This tests that the LTPA leader tracker can have cluster awareness of LTPA Secrets before operator reconciliation
+func TestReconcileLeaderTrackerWhenLTPASecretsExist(t *testing.T) {
+	logger := zap.New()
+	logf.SetLogger(logger)
+	os.Setenv("WATCH_NAMESPACE", namespace)
+
+	// Test default values no config
+	spec := wlv1.WebSphereLibertyApplicationSpec{}
+
+	// Create Liberty app
+	instance := createWebSphereLibertyApp(name, namespace, spec)
+	r := createReconcilerFromWebSphereLibertyApp(instance)
+
+	// Using the LTPA Decision Tree (complex) at version v10_4_1
+	latestOperandVersion := "v10_4_1"
+	fileName := getControllerFolder() + "/tests/ltpa-decision-tree-complex.yaml"
+	treeMap, replaceMap, err := tree.ParseDecisionTree(LTPA_RESOURCE_SHARING_FILE_NAME, &fileName)
+	tests := []Test{
+		{"parse decision tree complex", nil, err},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Firstly, Before initializing the leader tracker, create two LTPA Secrets based upon paths in ltpa-decision-tree-complex.yaml
+	ltpaRootName := "wlo-managed-ltpa"
+	complexSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ltpaRootName + "-b12g1", // random lower alphanumeric suffix of length 5
+			Namespace: namespace,
+			Labels: map[string]string{
+				lutils.ResourcePathIndexLabel: latestOperandVersion + ".2", // choosing path index 2 under tree v10_4_1 (i.e. v10_4_1.a.b.e.true)
+				"app.kubernetes.io/name":      ltpaRootName,
+			},
+		},
+		Data: map[string][]byte{}, // create empty data
+	}
+	complexSecret2 := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ltpaRootName + "-bazc1", // random lower alphanumeric suffix of length 5
+			Namespace: namespace,
+			Labels: map[string]string{
+				lutils.ResourcePathIndexLabel: latestOperandVersion + ".3", // choosing path index 3 under tree v10_4_1 (i.e. v10_4_1.a.b.e.false)
+				"app.kubernetes.io/name":      ltpaRootName,
+			},
+		},
+		Data: map[string][]byte{}, // create empty data
+	}
+	tests = []Test{
+		{"create LTPA Secret from based on path index 2 of complex decision tree", nil, r.CreateOrUpdate(complexSecret, nil, func() error { return nil })},
+		{"create LTPA Secret from based on path index 3 of complex decision tree", nil, r.CreateOrUpdate(complexSecret2, nil, func() error { return nil })},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Second, initialize the LTPA leader tracker
+	assetsFolder := getAssetsFolder()
+	tests = []Test{
+		{"initialize LTPA leader tracker error", nil, r.reconcileLeaderTracker(instance, treeMap, replaceMap, latestOperandVersion, LTPA_RESOURCE_SHARING_FILE_NAME, &assetsFolder)},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Lastly, check that the LTPA leader tracker processes the two LTPA Secrets created
+	leaderTracker, _, err := lutils.GetLeaderTracker(instance, OperatorShortName, LTPA_RESOURCE_SHARING_FILE_NAME, r.GetClient())
+	expectedLeaderTrackerData := map[string][]byte{
+		lutils.ResourcesKey:           []byte("-b12g1,-bazc1"),
+		lutils.ResourceOwnersKey:      []byte(","), // no owners associated with the LTPA Secrets because this decision tree (only for test) is not registered to use with the operator
+		lutils.ResourcePathsKey:       []byte("v10_4_1.a.b.e.true,v10_4_1.a.b.e.false"),
+		lutils.ResourcePathIndicesKey: []byte("v10_4_1.2,v10_4_1.3"),
+	}
+	tests = []Test{
+		{"get LTPA leader tracker error", nil, err},
+		{"get LTPA leader tracker name", "wlo-managed-leader-tracking-ltpa", leaderTracker.Name},
+		{"get LTPA leader tracker namespace", namespace, leaderTracker.Namespace},
+		{"get LTPA leader tracker data", expectedLeaderTrackerData, leaderTracker.Data},
+		{"get LTPA leader tracker label", latestOperandVersion, leaderTracker.Labels[lutils.LeaderVersionLabel]},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+// This tests that the LTPA leader tracker can have cluster awareness of LTPA Secrets before operator reconciliation and upgrade the LTPA Secrets to the latest decision tree version
+func TestReconcileLeaderTrackerWhenLTPASecretsExistWithUpgrade(t *testing.T) {
+	spec := wlv1.WebSphereLibertyApplicationSpec{}
+	instance := createWebSphereLibertyApp(name, namespace, spec)
+	r := createReconcilerFromWebSphereLibertyApp(instance)
+
+	fileName := getControllerFolder() + "/tests/ltpa-decision-tree-complex.yaml"
+	treeMap, replaceMap, err := tree.ParseDecisionTree(LTPA_RESOURCE_SHARING_FILE_NAME, &fileName)
+	tests := []Test{
+		{"parse decision tree complex", nil, err},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Firstly, Before initializing the leader tracker, create two LTPA Secrets based upon paths in ltpa-decision-tree-complex.yaml
+	latestOperandVersion := "v10_4_1"
+	ltpaRootName := "wlo-managed-ltpa"
+	complexSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ltpaRootName + "-b12g1", // random lower alphanumeric suffix of length 5
+			Namespace: namespace,
+			Labels: map[string]string{
+				lutils.ResourcePathIndexLabel: latestOperandVersion + ".2", // choosing path index 2 under tree v10_4_1 (i.e. v10_4_1.a.b.e.true)
+				"app.kubernetes.io/name":      ltpaRootName,
+			},
+		},
+		Data: map[string][]byte{}, // create empty data
+	}
+	complexSecret2 := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ltpaRootName + "-bazc1", // random lower alphanumeric suffix of length 5
+			Namespace: namespace,
+			Labels: map[string]string{
+				lutils.ResourcePathIndexLabel: latestOperandVersion + ".3", // choosing path index 3 under tree v10_4_1 (i.e. v10_4_1.a.b.e.false)
+				"app.kubernetes.io/name":      ltpaRootName,
+			},
+		},
+		Data: map[string][]byte{}, // create empty data
+	}
+	tests = []Test{
+		{"create LTPA Secret from based on path index 2 of complex decision tree", nil, r.CreateOrUpdate(complexSecret, nil, func() error { return nil })},
+		{"create LTPA Secret from based on path index 3 of complex decision tree", nil, r.CreateOrUpdate(complexSecret2, nil, func() error { return nil })},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Second, initialize the leader tracker but on a higher version of the LTPA decision tree
+	latestOperandVersion = "v10_4_20" // upgrade the version
+	assetsFolder := getAssetsFolder()
+	tests = []Test{
+		{"reconcileLeaderTracker at version v10_4_20", nil, r.reconcileLeaderTracker(instance, treeMap, replaceMap, latestOperandVersion, LTPA_RESOURCE_SHARING_FILE_NAME, &assetsFolder)},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Lastly, check that the LTPA leader tracker upgraded the two LTPA Secrets created
+	leaderTracker, _, err := lutils.GetLeaderTracker(instance, OperatorShortName, LTPA_RESOURCE_SHARING_FILE_NAME, r.GetClient())
+	expectedLeaderTrackerData := map[string][]byte{
+		lutils.ResourcesKey:           []byte("-b12g1,-bazc1"),
+		lutils.ResourceOwnersKey:      []byte(","),                                       // no owners associated with the LTPA Secrets because this decision tree (only for test) is not registered to use with the operator
+		lutils.ResourcePathsKey:       []byte("v10_4_20.a.b.e.foo,v10_4_20.a.f.g.i.bar"), // These paths have been upgraded to v10_4_20 based on replaceMap
+		lutils.ResourcePathIndicesKey: []byte("v10_4_20.2,v10_4_20.3"),                   // These path indices have been upgraded to v10_4_20 based on replaceMap
+	}
+	tests = []Test{
+		{"get LTPA leader tracker name", "wlo-managed-leader-tracking-ltpa", leaderTracker.Name},
+		{"get LTPA leader tracker namespace", namespace, leaderTracker.Namespace},
+		{"get LTPA leader tracker data", expectedLeaderTrackerData, leaderTracker.Data},
+		{"get LTPA leader tracker label", latestOperandVersion, leaderTracker.Labels[lutils.LeaderVersionLabel]},
+		{"get LTPA leader tracker error", nil, err},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+// This tests that the LTPA leader tracker can have cluster awareness of LTPA Secrets before operator reconciliation and upgrade the LTPA Secrets to the latest decision tree version
+func TestReconcileLeaderTrackerWhenLTPASecretsExistWithMultipleUpgradesAndDowngrades(t *testing.T) {
+	spec := wlv1.WebSphereLibertyApplicationSpec{}
+	instance := createWebSphereLibertyApp(name, namespace, spec)
+	r := createReconcilerFromWebSphereLibertyApp(instance)
+
+	fileName := getControllerFolder() + "/tests/ltpa-decision-tree-complex.yaml"
+	treeMap, replaceMap, err := tree.ParseDecisionTree(LTPA_RESOURCE_SHARING_FILE_NAME, &fileName)
+	tests := []Test{
+		{"parse decision tree complex", nil, err},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Firstly, Before initializing the leader tracker, create two LTPA Secrets based upon paths in ltpa-decision-tree-complex.yaml
+	latestOperandVersion := "v10_4_1"
+	ltpaRootName := "wlo-managed-ltpa"
+	complexSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ltpaRootName + "-b12g1", // random lower alphanumeric suffix of length 5
+			Namespace: namespace,
+			Labels: map[string]string{
+				lutils.ResourcePathIndexLabel: "v10_4_1.2", // choosing path index 2 under tree v10_4_1 (i.e. v10_4_1.a.b.e.true)
+				"app.kubernetes.io/name":      ltpaRootName,
+			},
+		},
+		Data: map[string][]byte{}, // create empty data
+	}
+	complexSecret2 := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ltpaRootName + "-bazc1", // random lower alphanumeric suffix of length 5
+			Namespace: namespace,
+			Labels: map[string]string{
+				lutils.ResourcePathIndexLabel: "v10_4_1.3", // choosing path index 3 under tree v10_4_1 (i.e. v10_4_1.a.b.e.false)
+				"app.kubernetes.io/name":      ltpaRootName,
+			},
+		},
+		Data: map[string][]byte{}, // create empty data
+	}
+	complexSecret3 := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ltpaRootName + "-ccccc", // random lower alphanumeric suffix of length 5
+			Namespace: namespace,
+			Labels: map[string]string{
+				lutils.ResourcePathIndexLabel: "v10_4_1.4", // choosing path index 4 under tree v10_4_1 (i.e. v10_4_1.j.fizz)
+				"app.kubernetes.io/name":      ltpaRootName,
+			},
+		},
+		Data: map[string][]byte{}, // create empty data
+	}
+	tests = []Test{
+		{"create LTPA Secret from based on path index 2 of complex decision tree", nil, r.CreateOrUpdate(complexSecret, nil, func() error { return nil })},
+		{"create LTPA Secret from based on path index 3 of complex decision tree", nil, r.CreateOrUpdate(complexSecret2, nil, func() error { return nil })},
+		{"create LTPA Secret from based on path index 4 of complex decision tree", nil, r.CreateOrUpdate(complexSecret3, nil, func() error { return nil })},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Second, initialize the leader tracker but on a higher version of the LTPA decision tree
+	latestOperandVersion = "v10_4_500" // upgrade the version
+	assetsFolder := getAssetsFolder()
+	tests = []Test{
+		{"reconcileLeaderTracker at version v10_4_500", nil, r.reconcileLeaderTracker(instance, treeMap, replaceMap, latestOperandVersion, LTPA_RESOURCE_SHARING_FILE_NAME, &assetsFolder)},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Thirdly, check that the LTPA leader tracker upgraded the two LTPA Secrets created
+	leaderTracker, _, err := lutils.GetLeaderTracker(instance, OperatorShortName, LTPA_RESOURCE_SHARING_FILE_NAME, r.GetClient())
+	expectedLeaderTrackerData := map[string][]byte{
+		lutils.ResourcesKey:           []byte("-b12g1,-bazc1,-ccccc"),
+		lutils.ResourceOwnersKey:      []byte(",,"),                                                        // no owners associated with the LTPA Secrets because this decision tree (only for test) is not registered to use with the operator
+		lutils.ResourcePathsKey:       []byte("v10_4_500.a.b.b.true,v10_4_500.a.f.g.i.bar,v10_4_1.j.fizz"), // These paths have been upgraded to v10_4_500 based on replaceMap
+		lutils.ResourcePathIndicesKey: []byte("v10_4_500.0,v10_4_500.4,v10_4_1.4"),                         // These path indices have been upgraded to v10_4_500 based on replaceMap
+	}
+	tests = []Test{
+		{"get LTPA leader tracker name", "wlo-managed-leader-tracking-ltpa", leaderTracker.Name},
+		{"get LTPA leader tracker namespace", namespace, leaderTracker.Namespace},
+		{"get LTPA leader tracker data", expectedLeaderTrackerData, leaderTracker.Data},
+		{"get LTPA leader tracker label", latestOperandVersion, leaderTracker.Labels[lutils.LeaderVersionLabel]},
+		{"get LTPA leader tracker error", nil, err},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Fourthly, downgrade the decision tree version and initialize the leader tracker (run initialize once to delete the old configMap)
+	latestOperandVersion = "v10_3_3"
+	tests = []Test{
+		{"Downgrade LTPA Leader Tracker from v10_4_500 to v10_3_3", nil, r.reconcileLeaderTracker(instance, treeMap, replaceMap, latestOperandVersion, LTPA_RESOURCE_SHARING_FILE_NAME, &assetsFolder)},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	r.reconcileLeaderTracker(instance, treeMap, replaceMap, latestOperandVersion, LTPA_RESOURCE_SHARING_FILE_NAME, &assetsFolder)
+
+	leaderTracker, _, err = lutils.GetLeaderTracker(instance, OperatorShortName, LTPA_RESOURCE_SHARING_FILE_NAME, r.GetClient())
+	expectedLeaderTrackerData = map[string][]byte{
+		lutils.ResourcesKey:           []byte("-b12g1,-bazc1,-ccccc"),
+		lutils.ResourceOwnersKey:      []byte(",,"),                                             // no owners associated with the LTPA Secrets because this decision tree (only for test) is not registered to use with the operator
+		lutils.ResourcePathsKey:       []byte("v10_3_3.a.b,v10_4_1.a.b.e.false,v10_4_1.j.fizz"), // v10_4_1 has no path to v10_3_3 so it is kept to be reference for a future upgrade
+		lutils.ResourcePathIndicesKey: []byte("v10_3_3.0,v10_4_1.3,v10_4_1.4"),                  // These path indices have been upgraded to v10_4_500 based on replaceMap
+	}
+	tests = []Test{
+		{"get LTPA leader tracker error", nil, err},
+		{"get LTPA leader tracker name", "wlo-managed-leader-tracking-ltpa", leaderTracker.Name},
+		{"get LTPA leader tracker namespace", namespace, leaderTracker.Namespace},
+		{"get LTPA leader tracker data", expectedLeaderTrackerData, leaderTracker.Data},
+		{"get LTPA leader tracker label", latestOperandVersion, leaderTracker.Labels[lutils.LeaderVersionLabel]},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func createReconcilerFromWebSphereLibertyApp(wlapp *wlv1.WebSphereLibertyApplication) *ReconcileWebSphereLiberty {
+	objs, s := []runtime.Object{wlapp}, scheme.Scheme
+	s.AddKnownTypes(wlv1.GroupVersion, wlapp)
+	cl := fakeclient.NewFakeClient(objs...)
+	rcl := fakeclient.NewFakeClient(objs...)
+	rb := oputils.NewReconcilerBase(rcl, cl, s, &rest.Config{}, record.NewFakeRecorder(10))
+	rol := &ReconcileWebSphereLiberty{
+		ReconcilerBase: rb,
+	}
+	return rol
+}
+
+func createWebSphereLibertyApp(n, ns string, spec wlv1.WebSphereLibertyApplicationSpec) *wlv1.WebSphereLibertyApplication {
+	app := &wlv1.WebSphereLibertyApplication{
+		ObjectMeta: metav1.ObjectMeta{Name: n, Namespace: ns},
+		Spec:       spec,
+	}
+	return app
+}
+
+func verifyTests(tests []Test) error {
+	for _, tt := range tests {
+		if !reflect.DeepEqual(tt.actual, tt.expected) {
+			return fmt.Errorf("%s test expected: (%v) actual: (%v)", tt.test, tt.expected, tt.actual)
+		}
+	}
+	return nil
+}

--- a/internal/controller/password_encryption_key_sharing.go
+++ b/internal/controller/password_encryption_key_sharing.go
@@ -1,0 +1,293 @@
+/*
+  Copyright contributors to the WASdev project.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	tree "github.com/OpenLiberty/open-liberty-operator/utils/tree"
+	wlv1 "github.com/WASdev/websphere-liberty-operator/api/v1"
+	lutils "github.com/WASdev/websphere-liberty-operator/utils"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const PASSWORD_ENCRYPTION_RESOURCE_SHARING_FILE_NAME = "password-encryption"
+
+func (r *ReconcileWebSphereLiberty) reconcilePasswordEncryptionKey(instance *wlv1.WebSphereLibertyApplication, passwordEncryptionMetadata *lutils.PasswordEncryptionMetadata) (string, string, error) {
+	if r.isPasswordEncryptionKeySharingEnabled(instance) {
+		_, thisInstanceIsLeader, _, err := r.reconcileLeader(instance, passwordEncryptionMetadata, PASSWORD_ENCRYPTION_RESOURCE_SHARING_FILE_NAME, true)
+		if err != nil && !kerrors.IsNotFound(err) {
+			return "", "", err
+		}
+		// non-leaders should still be able to pass this process to return the encryption secret name
+		if thisInstanceIsLeader {
+			// Is there a password encryption key to duplicate for internal use?
+			if err := r.mirrorEncryptionKeySecretState(instance, passwordEncryptionMetadata); err != nil {
+				return "Failed to process the password encryption key Secret", "", err
+			}
+		}
+
+		// Does the namespace already have a password encryption key sharing Secret?
+		encryptionSecret, err := r.hasInternalEncryptionKeySecret(instance, passwordEncryptionMetadata)
+		if err == nil {
+			// Is the password encryption key field in the Secret valid?
+			if encryptionKey := string(encryptionSecret.Data["passwordEncryptionKey"]); len(encryptionKey) > 0 {
+				// non-leaders should still be able to pass this process to return the encryption secret name
+				if thisInstanceIsLeader {
+					// Create the Liberty config that will mount into the pods
+					err := r.createPasswordEncryptionKeyLibertyConfig(instance, passwordEncryptionMetadata, encryptionKey)
+					if err != nil {
+						return "Failed to create Liberty resources to share the password encryption key", "", err
+					}
+				}
+				return "", encryptionSecret.Name, nil
+			}
+		} else if !kerrors.IsNotFound(err) {
+			return "Failed to get the password encryption key Secret", "", err
+		}
+	} else {
+		err := r.RemoveLeaderTrackerReference(instance, PASSWORD_ENCRYPTION_RESOURCE_SHARING_FILE_NAME)
+		if err != nil {
+			return "Failed to remove leader tracking reference to the password encryption key", "", err
+		}
+	}
+	return "", "", nil
+}
+
+func (r *ReconcileWebSphereLiberty) reconcilePasswordEncryptionMetadata(treeMap map[string]interface{}, latestOperandVersion string) (*lutils.PasswordEncryptionMetadata, error) {
+	metadata := &lutils.PasswordEncryptionMetadata{}
+
+	pathOptions, pathChoices := r.getPasswordEncryptionPathOptionsAndChoices(latestOperandVersion)
+
+	// convert the path options and choices into a labelString, for a path of length n, the labelString is
+	// constructed as a weaved array in format "<pathOptions[0]>.<pathChoices[0]>.<pathOptions[1]>.<pathChoices[1]>...<pathOptions[n-1]>.<pathChoices[n-1]>"
+	labelString, err := tree.GetLabelFromDecisionPath(latestOperandVersion, pathOptions, pathChoices)
+	if err != nil {
+		return metadata, err
+	}
+	// validate that the decision path such as "v1_4_0.managePasswordEncryption.true" is a valid subpath in treeMap
+	// an error here indicates a build time error created by the operator developer or pollution of the password-encryption-decision-tree.yaml
+	// NOTE: validSubPath is a substring of labelString and a valid path within treeMap; it will always hold that len(validSubPath) <= len(labelString)
+	validSubPath, err := tree.CanTraverseTree(treeMap, labelString, true)
+	if err != nil {
+		return metadata, err
+	}
+	// NOTE: Checking the leaderTracker can be skipped assuming there is only one password encryption key per namespace
+	// Leader tracker reconcile is only required to prevent overriding other shared resources (i.e. password encryption keys) in the same namespace
+	// Uncomment code below to extend to multiple password encryption keys per namespace. See ltpa_keys_sharing.go for an example.
+
+	// // retrieve the password encryption leader tracker to re-use an existing name or to create a new metadata.Name
+	// leaderTracker, _, err := lutils.GetLeaderTracker(instance, OperatorShortName, PASSWORD_ENCRYPTION_RESOURCE_SHARING_FILE_NAME, r.GetClient())
+	// if err != nil {
+	// 	return metadata, err
+	// }
+	// // if the leaderTracker is on a mismatched version, wait for a subsequent reconcile loop to re-create the leader tracker
+	// if leaderTracker.Labels[lutils.LeaderVersionLabel] != latestOperandVersion {
+	// 	return metadata, fmt.Errorf("waiting for the Leader Tracker to be updated")
+	// }
+
+	// to avoid limitation with Kubernetes label values having a max length of 63, translate validSubPath into a path index
+	pathIndex := tree.GetLeafIndex(treeMap, validSubPath)
+	versionedPathIndex := fmt.Sprintf("%s.%d", latestOperandVersion, pathIndex)
+
+	metadata.Path = validSubPath
+	metadata.PathIndex = versionedPathIndex
+	metadata.Name = r.getPasswordEncryptionMetadataName() // You could augment this function to extend to multiple password encryption keys per namespace. See ltpa_keys_sharing.go for an example.
+	return metadata, nil
+}
+
+func (r *ReconcileWebSphereLiberty) getPasswordEncryptionPathOptionsAndChoices(latestOperandVersion string) ([]string, []string) {
+	var pathOptions, pathChoices []string
+	if latestOperandVersion == "v1_4_0" {
+		pathOptions = []string{"managePasswordEncryption"}
+		pathChoices = []string{"true"} // there is only one possible password encryption key per namespace which corresponds to one path only
+	}
+	return pathOptions, pathChoices
+}
+
+func (r *ReconcileWebSphereLiberty) getPasswordEncryptionMetadataName() string {
+	// NOTE: there is only one possible password encryption key per namespace which corresponds to one shared resource name from password-encryption-signature.yaml
+	// If you would like to have more than one password encryption key in a single namespace, use ltpa-signature.yaml as a template
+	//
+	// _, sharedResourceName, err := lutils.CreateUnstructuredResourceFromSignature(PASSWORD_ENCRYPTION_RESOURCE_SHARING_FILE_NAME, OperatorShortName, "")
+	// if err != nil {
+	// 	return "", err
+	// }
+	// return sharedResourceName, nil
+	return "" // there is only one password encryption key per namespace which is represented by the empty string suffix
+}
+
+func (r *ReconcileWebSphereLiberty) isPasswordEncryptionKeySharingEnabled(instance *wlv1.WebSphereLibertyApplication) bool {
+	return instance.GetManagePasswordEncryption() != nil && *instance.GetManagePasswordEncryption()
+}
+
+func (r *ReconcileWebSphereLiberty) isUsingPasswordEncryptionKeySharing(instance *wlv1.WebSphereLibertyApplication, passwordEncryptionMetadata *lutils.PasswordEncryptionMetadata) bool {
+	if r.isPasswordEncryptionKeySharingEnabled(instance) {
+		_, err := r.hasUserEncryptionKeySecret(instance, passwordEncryptionMetadata)
+		return err == nil
+	}
+	return false
+}
+
+// Returns the Secret that contains the password encryption key used internally by the operator
+func (r *ReconcileWebSphereLiberty) hasInternalEncryptionKeySecret(instance *wlv1.WebSphereLibertyApplication, passwordEncryptionMetadata *lutils.PasswordEncryptionMetadata) (*corev1.Secret, error) {
+	return r.getSecret(instance, lutils.PasswordEncryptionKeyRootName+passwordEncryptionMetadata.Name+"-internal")
+}
+
+// Returns the Secret that contains the password encryption key provided by the user
+func (r *ReconcileWebSphereLiberty) hasUserEncryptionKeySecret(instance *wlv1.WebSphereLibertyApplication, passwordEncryptionMetadata *lutils.PasswordEncryptionMetadata) (*corev1.Secret, error) {
+	return r.getSecret(instance, lutils.PasswordEncryptionKeyRootName+passwordEncryptionMetadata.Name)
+}
+
+func (r *ReconcileWebSphereLiberty) mirrorEncryptionKeySecretState(instance *wlv1.WebSphereLibertyApplication, passwordEncryptionMetadata *lutils.PasswordEncryptionMetadata) error {
+	userEncryptionSecret, userEncryptionSecretErr := r.hasUserEncryptionKeySecret(instance, passwordEncryptionMetadata)
+	// Error if there was an issue getting the userEncryptionSecret
+	if userEncryptionSecretErr != nil && !kerrors.IsNotFound(userEncryptionSecretErr) {
+		return userEncryptionSecretErr
+	}
+	internalEncryptionSecret, internalEncryptionSecretErr := r.hasInternalEncryptionKeySecret(instance, passwordEncryptionMetadata)
+	// Error if there was an issue getting the internalEncryptionSecret
+	if internalEncryptionSecretErr != nil && !kerrors.IsNotFound(internalEncryptionSecretErr) {
+		return internalEncryptionSecretErr
+	}
+	// Case 0: no user encryption secret, no internal encryption secret: secrets already mirrored
+	// Case 1: no user encryption secret, internal encryption secret exists: so delete internalEncryptionSecret
+	if kerrors.IsNotFound(userEncryptionSecretErr) {
+		if kerrors.IsNotFound(internalEncryptionSecretErr) {
+			return nil
+		} else {
+			if err := r.DeleteResource(internalEncryptionSecret); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Case 2: user encryption secret exists, no internal secret: Create internalEncryptionSecret
+	// Case 3: user encryption secret exists, internal secret exists: Update internalEncryptionSecret
+	return r.CreateOrUpdate(internalEncryptionSecret, nil, func() error {
+		if internalEncryptionSecret.Data == nil {
+			internalEncryptionSecret.Data = make(map[string][]byte)
+		}
+		if userEncryptionSecret.Data == nil {
+			userEncryptionSecret.Data = make(map[string][]byte)
+		}
+		internalPasswordEncryptionKey := internalEncryptionSecret.Data["passwordEncryptionKey"]
+		userPasswordEncryptionKey := userEncryptionSecret.Data["passwordEncryptionKey"]
+		if string(internalPasswordEncryptionKey) != string(userPasswordEncryptionKey) {
+			internalEncryptionSecret.Data["passwordEncryptionKey"] = userPasswordEncryptionKey
+			internalEncryptionSecret.Data["lastRotation"] = []byte(fmt.Sprint(time.Now().Unix()))
+		}
+		return nil
+	})
+}
+
+// Deletes the mirrored encryption key secret if the initial encryption key secret no longer exists
+func (r *ReconcileWebSphereLiberty) deleteMirroredEncryptionKeySecret(instance *wlv1.WebSphereLibertyApplication, passwordEncryptionMetadata *lutils.PasswordEncryptionMetadata) error {
+	_, userEncryptionSecretErr := r.hasUserEncryptionKeySecret(instance, passwordEncryptionMetadata)
+	// Error if there was an issue getting the userEncryptionSecret
+	if userEncryptionSecretErr != nil && !kerrors.IsNotFound(userEncryptionSecretErr) {
+		return userEncryptionSecretErr
+	}
+	internalEncryptionSecret, internalEncryptionSecretErr := r.hasInternalEncryptionKeySecret(instance, passwordEncryptionMetadata)
+	// Error if there was an issue getting the internalEncryptionSecret
+	if internalEncryptionSecretErr != nil && !kerrors.IsNotFound(internalEncryptionSecretErr) {
+		return internalEncryptionSecretErr
+	}
+	// Case 1: no user encryption secret, internal encryption secret exists: so delete internalEncryptionSecret
+	if kerrors.IsNotFound(userEncryptionSecretErr) && !kerrors.IsNotFound(internalEncryptionSecretErr) {
+		if err := r.DeleteResource(internalEncryptionSecret); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *ReconcileWebSphereLiberty) getSecret(instance *wlv1.WebSphereLibertyApplication, secretName string) (*corev1.Secret, error) {
+	secret := &corev1.Secret{}
+	secret.Name = secretName
+	secret.Namespace = instance.GetNamespace()
+	secret.Labels = lutils.GetRequiredLabels(secret.Name, "")
+	err := r.GetClient().Get(context.TODO(), types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace}, secret)
+	return secret, err
+}
+
+// Creates the Liberty XML to mount the password encryption keys Secret into the application pods
+func (r *ReconcileWebSphereLiberty) createPasswordEncryptionKeyLibertyConfig(instance *wlv1.WebSphereLibertyApplication, passwordEncryptionMetadata *lutils.PasswordEncryptionMetadata, encryptionKey string) error {
+	if len(encryptionKey) == 0 {
+		return fmt.Errorf("a password encryption key was not specified")
+	}
+
+	// The Secret to hold the server.xml that will override the password encryption key for the Liberty server
+	// This server.xml will be mounted in /output/resources/liberty-operator/encryptionKey.xml
+	encryptionXMLSecretName := OperatorShortName + lutils.ManagedEncryptionServerXML + passwordEncryptionMetadata.Name
+	encryptionXMLSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      encryptionXMLSecretName,
+			Namespace: instance.GetNamespace(),
+			Labels:    lutils.GetRequiredLabels(encryptionXMLSecretName, ""),
+		},
+	}
+	if err := r.CreateOrUpdate(encryptionXMLSecret, nil, func() error {
+		return lutils.CustomizeEncryptionKeyXML(encryptionXMLSecret, encryptionKey)
+	}); err != nil {
+		return err
+	}
+
+	// The Secret to hold the server.xml that will import the password encryption key into the Liberty server
+	// This server.xml will be mounted in /config/configDropins/overrides/encryptionKeyMount.xml
+	mountingXMLSecretName := OperatorShortName + lutils.ManagedEncryptionMountServerXML + passwordEncryptionMetadata.Name
+	mountingXMLSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      mountingXMLSecretName,
+			Namespace: instance.GetNamespace(),
+			Labels:    lutils.GetRequiredLabels(mountingXMLSecretName, ""),
+		},
+	}
+	if err := r.CreateOrUpdate(mountingXMLSecret, nil, func() error {
+		mountDir := strings.Replace(lutils.SecureMountPath+"/"+lutils.EncryptionKeyXMLFileName, "/output", "${server.output.dir}", 1)
+		return lutils.CustomizeLibertyFileMountXML(mountingXMLSecret, lutils.EncryptionKeyMountXMLFileName, mountDir)
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Tracks existing password encryption resources by populating a LeaderTracker array used to initialize the LeaderTracker
+func (r *ReconcileWebSphereLiberty) GetPasswordEncryptionResources(instance *wlv1.WebSphereLibertyApplication, treeMap map[string]interface{}, replaceMap map[string]map[string]string, latestOperandVersion string, assetsFolder *string) (*unstructured.UnstructuredList, string, error) {
+	passwordEncryptionResources, err := lutils.CreateUnstructuredResourceListFromSignature(PASSWORD_ENCRYPTION_RESOURCE_SHARING_FILE_NAME, assetsFolder, "") // TODO: replace prefix "" to specify operator precedence such as with prefix "wlo-"
+	if err != nil {
+		return nil, "", err
+	}
+	passwordEncryptionResource, passwordEncryptionResourceName, err := lutils.CreateUnstructuredResourceFromSignature(PASSWORD_ENCRYPTION_RESOURCE_SHARING_FILE_NAME, assetsFolder, "", "") // TODO: replace prefix "" to specify operator precedence such as with prefix "wlo-"
+	if err != nil {
+		return nil, "", err
+	}
+	if err := r.GetClient().Get(context.TODO(), types.NamespacedName{Name: passwordEncryptionResourceName, Namespace: instance.GetNamespace()}, passwordEncryptionResource); err == nil {
+		passwordEncryptionResources.Items = append(passwordEncryptionResources.Items, *passwordEncryptionResource)
+	} else if !kerrors.IsNotFound(err) {
+		return nil, "", err
+	}
+	return passwordEncryptionResources, passwordEncryptionResourceName, nil
+}

--- a/internal/controller/resource_sharing.go
+++ b/internal/controller/resource_sharing.go
@@ -1,0 +1,309 @@
+/*
+  Copyright contributors to the WASdev project.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	tree "github.com/OpenLiberty/open-liberty-operator/utils/tree"
+	wlv1 "github.com/WASdev/websphere-liberty-operator/api/v1"
+	lutils "github.com/WASdev/websphere-liberty-operator/utils"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// Validates the resource decision tree YAML and generates the leader tracking state (Secret) for maintaining multiple shared resources
+func (r *ReconcileWebSphereLiberty) reconcileResourceTrackingState(instance *wlv1.WebSphereLibertyApplication, leaderTrackerType string) (lutils.LeaderTrackerMetadata, error) {
+	treeMap, replaceMap, err := tree.ParseDecisionTree(leaderTrackerType, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	latestOperandVersion, err := tree.GetLatestOperandVersion(treeMap, "")
+	if err != nil {
+		return nil, err
+	}
+
+	// persist or create a Secret to store the shared resources' state
+	err = r.reconcileLeaderTracker(instance, treeMap, replaceMap, latestOperandVersion, leaderTrackerType, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// return the metadata specific to the operator version, instance configuration, and shared resource being reconciled
+	if leaderTrackerType == LTPA_RESOURCE_SHARING_FILE_NAME {
+		ltpaMetadata, err := r.reconcileLTPAMetadata(instance, treeMap, latestOperandVersion, nil)
+		if err != nil {
+			return nil, err
+		}
+		return ltpaMetadata, nil
+	}
+	if leaderTrackerType == PASSWORD_ENCRYPTION_RESOURCE_SHARING_FILE_NAME {
+		passwordEncryptionMetadata, err := r.reconcilePasswordEncryptionMetadata(treeMap, latestOperandVersion)
+		if err != nil {
+			return nil, err
+		}
+		return passwordEncryptionMetadata, nil
+	}
+	return nil, fmt.Errorf("a leaderTrackerType was not provided when running reconcileResourceTrackingState")
+}
+
+// If shouldElectNewLeader is set to true, the WebSphereLibertyApplication instance will be set and returned as the resource leader
+// Otherwise, returns the current shared resource leader
+func (r *ReconcileWebSphereLiberty) reconcileLeader(instance *wlv1.WebSphereLibertyApplication, leaderMetadata lutils.LeaderTrackerMetadata, leaderTrackerType string, shouldElectNewLeader bool) (string, bool, string, error) {
+	leaderTracker, leaderTrackers, err := lutils.GetLeaderTracker(instance, OperatorShortName, leaderTrackerType, r.GetClient())
+	if err != nil {
+		return "", false, "", err
+	}
+	return r.reconcileLeaderWithState(instance, leaderTracker, leaderTrackers, leaderMetadata, shouldElectNewLeader)
+}
+
+func (r *ReconcileWebSphereLiberty) reconcileLeaderWithState(instance *wlv1.WebSphereLibertyApplication, leaderTracker *corev1.Secret, leaderTrackers *[]lutils.LeaderTracker, leaderMetadata lutils.LeaderTrackerMetadata, shouldElectNewLeader bool) (string, bool, string, error) {
+	initialLeaderIndex := -1
+	for i, tracker := range *leaderTrackers {
+		if tracker.Name == leaderMetadata.GetName() {
+			initialLeaderIndex = i
+		}
+	}
+	// if the tracked resource does not exist in resources labels, this instance is leader
+	if initialLeaderIndex == -1 {
+		if !shouldElectNewLeader {
+			return "", false, "", nil
+		}
+		// clear instance.Name from ownership of any prior resources
+		for i := range *leaderTrackers {
+			(*leaderTrackers)[i].ClearOwnerIfMatching(instance.Name)
+		}
+		// make instance.Name the new leader
+		newLeader := lutils.LeaderTracker{
+			Name:      leaderMetadata.GetName(),
+			Owner:     instance.Name,
+			PathIndex: leaderMetadata.GetPathIndex(),
+			Path:      leaderMetadata.GetPath(),
+			// Sublease:  fmt.Sprint(time.Now().Unix()),
+		}
+		// append it to the list of leaders
+		*leaderTrackers = append(*leaderTrackers, newLeader)
+		// save the tracker state
+		if err := r.SaveLeaderTracker(leaderTracker, leaderTrackers); err != nil {
+			return "", false, "", err
+		}
+		return instance.Name, true, leaderMetadata.GetPathIndex(), nil
+	}
+	// otherwise, the resource is being tracked
+	// if the leader of the tracked resource is non empty decide whether or not to return the resource owner
+	candidateLeader := (*leaderTrackers)[initialLeaderIndex].Owner
+	if len(candidateLeader) > 0 {
+		// Return this other instance as the leader (the "other" instance could also be this instance)
+		// Before returning, if the candidate instance is not this instance, this instance must clean up its old owner references to avoid an resource owner cycle.
+		// A resource owner cycle can occur when instance A points to resource A and instance B points to resource B but then both instance A and B swap pointing to each other's resource.
+		if candidateLeader != instance.Name {
+			// clear instance.Name from ownership of any prior resources and evict the owner if the sublease has expired
+			for i := range *leaderTrackers {
+				(*leaderTrackers)[i].ClearOwnerIfMatching(instance.Name)
+				// (*leaderTrackers)[i].EvictOwnerIfSubleaseHasExpired()
+			}
+		}
+		// else {
+		// candidate is this instance, so renew the sublease
+		// (*leaderTrackers)[initialLeaderIndex].RenewSublease()
+		// }
+
+		// If the current owner has been evicted, use this instance as the new owner
+		currentOwner := (*leaderTrackers)[initialLeaderIndex].Owner
+		if currentOwner == "" {
+			currentOwner = instance.Name
+			(*leaderTrackers)[initialLeaderIndex].SetOwner(currentOwner)
+		}
+		// save this new owner list
+		if err := r.SaveLeaderTracker(leaderTracker, leaderTrackers); err != nil {
+			return "", false, "", err
+		}
+		return currentOwner, currentOwner == instance.Name, (*leaderTrackers)[initialLeaderIndex].PathIndex, nil
+	}
+	if !shouldElectNewLeader {
+		return "", false, "", nil
+	}
+	// there is either no leader (empty string) or the leader was deleted so now this instance is leader
+	pathIndex := ""
+	for i := range *leaderTrackers {
+		if i == initialLeaderIndex {
+			pathIndex = (*leaderTrackers)[i].PathIndex
+			(*leaderTrackers)[i].SetOwner(instance.Name)
+		} else {
+			(*leaderTrackers)[i].ClearOwnerIfMatching(instance.Name)
+		}
+	}
+	// save this new owner list
+	if err := r.SaveLeaderTracker(leaderTracker, leaderTrackers); err != nil {
+		return "", false, "", err
+	}
+	return instance.Name, true, pathIndex, nil
+}
+
+func (r *ReconcileWebSphereLiberty) createNewLeaderTrackerList(instance *wlv1.WebSphereLibertyApplication, treeMap map[string]interface{}, replaceMap map[string]map[string]string, latestOperandVersion string, leaderTrackerType string, assetsFolder *string) (*[]lutils.LeaderTracker, error) {
+	var resourcesList *unstructured.UnstructuredList
+	var resourceRootName string
+	var err error
+
+	if leaderTrackerType == LTPA_RESOURCE_SHARING_FILE_NAME {
+		resourcesList, resourceRootName, err = r.GetLTPAResources(instance, treeMap, replaceMap, latestOperandVersion, assetsFolder)
+	} else if leaderTrackerType == PASSWORD_ENCRYPTION_RESOURCE_SHARING_FILE_NAME {
+		resourcesList, resourceRootName, err = r.GetPasswordEncryptionResources(instance, treeMap, replaceMap, latestOperandVersion, assetsFolder)
+	} else {
+		err = fmt.Errorf("a valid leaderTrackerType was not specified for createNewLeaderTrackerList")
+	}
+	if err != nil {
+		return nil, err
+	}
+	return r.GetLeaderTrackersFromUnstructuredList(resourcesList, treeMap, replaceMap, latestOperandVersion, resourceRootName)
+}
+
+// Reconciles the latest LeaderTracker state to be used by the operator
+func (r *ReconcileWebSphereLiberty) reconcileLeaderTracker(instance *wlv1.WebSphereLibertyApplication, treeMap map[string]interface{}, replaceMap map[string]map[string]string, latestOperandVersion string, leaderTrackerType string, assetsFolder *string) error {
+	leaderTracker, _, err := lutils.GetLeaderTracker(instance, OperatorShortName, leaderTrackerType, r.GetClient())
+	// If the Leader Tracker is missing, create from scratch
+	if err != nil && kerrors.IsNotFound(err) {
+		leaderTracker.Labels[lutils.LeaderVersionLabel] = latestOperandVersion
+		leaderTracker.ResourceVersion = ""
+		leaderTrackers, err := r.createNewLeaderTrackerList(instance, treeMap, replaceMap, latestOperandVersion, leaderTrackerType, assetsFolder)
+		if err != nil {
+			return err
+		}
+		return r.SaveLeaderTracker(leaderTracker, leaderTrackers)
+	} else if err != nil {
+		return err
+	}
+	// If the Leader Tracker is outdated, delete it so that it gets recreated in another reconcile
+	if leaderTracker.Labels[lutils.LeaderVersionLabel] != latestOperandVersion {
+		if err := r.DeleteResource(leaderTracker); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *ReconcileWebSphereLiberty) SaveLeaderTracker(leaderTracker *corev1.Secret, trackerList *[]lutils.LeaderTracker) error {
+	return r.CreateOrUpdate(leaderTracker, nil, func() error {
+		lutils.CustomizeLeaderTracker(leaderTracker, trackerList)
+		return nil
+	})
+}
+
+// Removes the instance as leader if instance is the leader and if no leaders are being tracked then delete the leader tracking Secret
+func (r *ReconcileWebSphereLiberty) RemoveLeader(instance *wlv1.WebSphereLibertyApplication, leaderTracker *corev1.Secret, leaderTrackers *[]lutils.LeaderTracker) error {
+	changeDetected := false
+	noOwners := true
+	// If the instance is being tracked, remove it
+	for i := range *leaderTrackers {
+		if (*leaderTrackers)[i].ClearOwnerIfMatching(instance.Name) {
+			changeDetected = true
+		}
+		if (*leaderTrackers)[i].Owner != "" {
+			noOwners = false
+		}
+	}
+	if noOwners {
+		if err := r.DeleteResource(leaderTracker); err != nil {
+			return err
+		}
+	} else if changeDetected {
+		if err := r.SaveLeaderTracker(leaderTracker, leaderTrackers); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *ReconcileWebSphereLiberty) GetLeaderTrackersFromUnstructuredList(resourceList *unstructured.UnstructuredList, treeMap map[string]interface{}, replaceMap map[string]map[string]string, latestOperandVersion string, resourceRootName string) (*[]lutils.LeaderTracker, error) {
+	leaderTrackers := make([]lutils.LeaderTracker, 0)
+	for i, resource := range resourceList.Items {
+		labelsMap, _, err := unstructured.NestedMap(resource.Object, "metadata", "labels")
+		if err != nil {
+			return nil, err
+		}
+		if pathIndexInterface, found := labelsMap[lutils.ResourcePathIndexLabel]; found {
+			pathIndex := pathIndexInterface.(string)
+			// Skip this resource if path index does not contain a period separating delimeter
+			if !strings.Contains(pathIndex, ".") {
+				continue
+			}
+			labelVersionArray := strings.Split(pathIndex, ".")
+			// Skip this resource if the path index is not a tuple representing the version and index
+			if len(labelVersionArray) != 2 {
+				continue
+			}
+			leader := lutils.LeaderTracker{
+				PathIndex: pathIndex,
+			}
+			indexIntVal, _ := strconv.ParseInt(labelVersionArray[1], 10, 64)
+			path, pathErr := tree.GetPathFromLeafIndex(treeMap, labelVersionArray[0], int(indexIntVal))
+			// If path comes from a different operand version, the path needs to be upgraded/downgraded to the latestOperandVersion
+			if pathErr == nil && labelVersionArray[0] != latestOperandVersion {
+				// If user error has occurred, based on whether or not a dev deleted the decision tree structure of an older version
+				// allow this condition to error (when err != nil) so that a deleted (older) revision of the decision tree that may be missing
+				// won't halt the operator when the ReplacePath validation is performed
+				if path, err := tree.ReplacePath(path, latestOperandVersion, treeMap, replaceMap); err == nil {
+					newPathIndex := strings.Split(path, ".")[0] + "." + strconv.FormatInt(int64(tree.GetLeafIndex(treeMap, path)), 10)
+					leader.PathIndex = newPathIndex
+					leader.Path = path
+					// the path may have changed so the path index reference needs to be updated directly in the resource
+					if err := r.CreateOrUpdate(&resourceList.Items[i], nil, func() error {
+						labelsMap, _, err := unstructured.NestedMap(resourceList.Items[i].Object, "metadata", "labels")
+						if err != nil {
+							return err
+						}
+						labelsMap[lutils.ResourcePathIndexLabel] = newPathIndex
+						if err := unstructured.SetNestedMap(resourceList.Items[i].Object, labelsMap, "metadata", "labels"); err != nil {
+							return err
+						}
+						return nil
+					}); err != nil {
+						return nil, err
+					}
+				}
+			} else if pathErr == nil { // only update the path metadata if this operator's decision tree structure recognizes the resource
+				leader.Path = path
+			} else {
+				// A valid decision tree path could not be found, so it will not be used by the operator and this resource will not be tracked
+				continue
+			}
+			nameString, _, err := unstructured.NestedString(resource.Object, "metadata", "name")
+			if err != nil {
+				return nil, err
+			}
+			leader.Name = nameString[len(resourceRootName):]
+			leader.EvictOwner()
+			lutils.InsertIntoSortedLeaderTrackers(&leaderTrackers, &leader)
+		}
+	}
+	return &leaderTrackers, nil
+}
+
+func (r *ReconcileWebSphereLiberty) RemoveLeaderTrackerReference(instance *wlv1.WebSphereLibertyApplication, resourceSharingFileName string) error {
+	leaderTracker, leaderTrackers, err := lutils.GetLeaderTracker(instance, OperatorShortName, resourceSharingFileName, r.GetClient())
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	return r.RemoveLeader(instance, leaderTracker, leaderTrackers)
+}

--- a/internal/controller/tests/invalid-wlo-signature.yaml
+++ b/internal/controller/tests/invalid-wlo-signature.yaml
@@ -1,0 +1,3 @@
+apiVersion: v1
+kind: Secret
+name

--- a/internal/controller/tests/ltpa-decision-tree-1-generation.yaml
+++ b/internal/controller/tests/ltpa-decision-tree-1-generation.yaml
@@ -1,0 +1,3 @@
+tree:
+  v10_3_3: test
+replace: {}

--- a/internal/controller/tests/ltpa-decision-tree-2-generations.yaml
+++ b/internal/controller/tests/ltpa-decision-tree-2-generations.yaml
@@ -1,0 +1,19 @@
+tree:
+  v10_4_0:
+    managePasswordEncryption:
+      - true
+      - false
+    test: test
+# NOTE: this uses maps always as an edge. Lists can only exist at the leaf node to represent enumerated booleans or strings.
+  v10_4_1:
+    type:
+      aes:
+        managePasswordEncryption:
+          - true
+          - false
+      xor: type # "type" is a dummy string to create a leaf node in the tree to represent when a type: xor LTPA keys is used, it could also be a boolean
+replace:
+  v10_4_1:
+    "v10_4_0.managePasswordEncryption.true":  "v10_4_1.type.aes.managePasswordEncryption.true"
+    "v10_4_0.managePasswordEncryption.false": "v10_4_1.type.aes.managePasswordEncryption.false"
+    "v10_4_0.test.test": "v10_4_1.type.xor.type"

--- a/internal/controller/tests/ltpa-decision-tree-3-generations.yaml
+++ b/internal/controller/tests/ltpa-decision-tree-3-generations.yaml
@@ -1,0 +1,23 @@
+tree:
+  v10_3_3: 
+    manageLTPA: true
+  v10_4_0:
+    managePasswordEncryption:
+      - true
+      - false
+      - test
+  v10_4_1:
+    type:
+      aes:
+        managePasswordEncryption:
+          - true
+          - false
+          - test
+      xor: type # "type" is a dummy string to create a leaf node in the tree to represent when a type: xor LTPA keys is used, it could also be a boolean
+replace:
+  v10_4_0:
+    "v10_3_3.manageLTPA.true": "v10_4_0.managePasswordEncryption.false"
+  v10_4_1:
+    "v10_4_0.managePasswordEncryption.true":  "v10_4_1.type.aes.managePasswordEncryption.true"
+    "v10_4_0.managePasswordEncryption.false": "v10_4_1.type.aes.managePasswordEncryption.false"
+    "v10_4_0.managePasswordEncryption.test":  "v10_4_1.type.aes.managePasswordEncryption.test"

--- a/internal/controller/tests/ltpa-decision-tree-complex.yaml
+++ b/internal/controller/tests/ltpa-decision-tree-complex.yaml
@@ -1,0 +1,51 @@
+tree:
+  v10_2_2: test
+  v10_3_3:
+    a: b # 0
+  v10_4_1:
+    a:
+      b: 
+        c: true # 0
+        e:
+          - true # 2
+          - false # 3
+        d: true # 1
+    j: fizz # 4 (this element appears only in v10_4_1, but is deprecated in all other versions because no replace command exists)
+  v10_4_20:
+    a:
+      b:
+        e: foo # 2
+        c: true # 0
+        d: false # 1
+      f:
+        h: element # 4
+        g:
+          i: bar # 3
+  v10_4_500:
+    a:
+      b:
+        d: false # 2
+        b: true # 0
+        e: foo # 3
+        c: true # 1
+      f:
+        h: element # 5
+        g:
+          i: bar # 4
+replace:
+  v10_3_3:
+    "v10_2_2.test": "v10_3_3.a.b"
+  v10_4_1:
+    "v10_3_3.a.b": "v10_4_1.a.b.e.true"
+  v10_4_20:
+    "v10_4_1.a.b.c.true": "v10_4_20.a.b.c.true"
+    "v10_4_1.a.b.d.true": "v10_4_20.a.b.d.false"
+    "v10_4_1.a.b.e.true": "v10_4_20.a.b.e.foo"
+    "v10_4_1.a.b.e.false": "v10_4_20.a.f.g.i.bar"
+  v10_4_500:
+    "v10_4_20.a.b.d.false": "v10_4_500.a.b.d.false"
+    "v10_4_20.a.b.c.true": "v10_4_500.a.b.c.true"
+    "v10_4_20.a.b.e.foo": "v10_4_500.a.b.b.true"
+    "v10_4_20.a.f.g.i.bar": "v10_4_500.a.f.g.i.bar"
+    "v10_4_20.a.f.h.element": "v10_4_500.a.f.h.element"
+      

--- a/internal/controller/tests/user-error-wlo-signature.yaml
+++ b/internal/controller/tests/user-error-wlo-signature.yaml
@@ -1,0 +1,2 @@
+apiVersion: v1
+name: helloworld

--- a/internal/controller/tests/wlo-signature.yaml
+++ b/internal/controller/tests/wlo-signature.yaml
@@ -1,0 +1,3 @@
+apiVersion: liberty.websphere.ibm.com/v1
+kind: WebSphereLibertyApplication
+name: "{0}-managed-wlapp"

--- a/internal/controller/webspherelibertyapplication_controller.go
+++ b/internal/controller/webspherelibertyapplication_controller.go
@@ -145,6 +145,8 @@ func (r *ReconcileWebSphereLiberty) Reconcile(ctx context.Context, request ctrl.
 		return r.ManageError(err, common.StatusConditionTypeReconciled, instance)
 	}
 
+	passwordEncryptionMetadata := &lutils.PasswordEncryptionMetadata{Name: ""}
+
 	// Check if the WebSphereLibertyApplication instance is marked to be deleted, which is
 	// indicated by the deletion timestamp being set.
 	isInstanceMarkedToBeDeleted := instance.GetDeletionTimestamp() != nil
@@ -237,13 +239,32 @@ func (r *ReconcileWebSphereLiberty) Reconcile(ctx context.Context, request ctrl.
 			}
 		}
 	}
+
+	// Reconciles the shared LTPA state for the instance namespace
+	var ltpaMetadata *lutils.LTPAMetadata
+	if r.isLTPAKeySharingEnabled(instance) {
+		leaderMetadata, err := r.reconcileResourceTrackingState(instance, LTPA_RESOURCE_SHARING_FILE_NAME)
+		if err != nil {
+			return r.ManageError(err, common.StatusConditionTypeReconciled, instance)
+		}
+		ltpaMetadata = leaderMetadata.(*lutils.LTPAMetadata)
+	}
+	// Reconciles the shared password encryption key state for the instance namespace only if the shared key already exists
+	if r.isUsingPasswordEncryptionKeySharing(instance, passwordEncryptionMetadata) {
+		leaderMetadata, err := r.reconcileResourceTrackingState(instance, PASSWORD_ENCRYPTION_RESOURCE_SHARING_FILE_NAME)
+		if err != nil {
+			return r.ManageError(err, common.StatusConditionTypeReconciled, instance)
+		}
+		passwordEncryptionMetadata = leaderMetadata.(*lutils.PasswordEncryptionMetadata)
+	}
+
 	if imageReferenceOld != instance.Status.ImageReference {
 		// Trigger a new Semeru Cloud Compiler generation
 		createNewSemeruGeneration(instance)
 
 		// If the shared LTPA keys was not generated from the last application image, restart the key generation process
 		if r.isLTPAKeySharingEnabled(instance) {
-			if err := r.restartLTPAKeysGeneration(instance); err != nil {
+			if err := r.restartLTPAKeysGeneration(instance, ltpaMetadata); err != nil {
 				reqLogger.Error(err, "Error restarting the LTPA keys generation process")
 				return r.ManageError(err, common.StatusConditionTypeReconciled, instance)
 			}
@@ -441,7 +462,15 @@ func (r *ReconcileWebSphereLiberty) Reconcile(ctx context.Context, request ctrl.
 		return r.ManageError(err, common.StatusConditionTypeReconciled, instance)
 	}
 
-	err, message, ltpaSecretName := r.reconcileLTPAKeysSharing(instance)
+	// Manage the shared password encryption key Secret if it exists
+	message, encryptionSecretName, err := r.reconcilePasswordEncryptionKey(instance, passwordEncryptionMetadata)
+	if err != nil {
+		reqLogger.Error(err, message)
+		return r.ManageError(err, common.StatusConditionTypeReconciled, instance)
+	}
+
+	// Create and manage the shared LTPA keys Secret if the feature is enabled
+	message, ltpaSecretName, err := r.reconcileLTPAKeys(instance, ltpaMetadata)
 	if err != nil {
 		reqLogger.Error(err, message)
 		return r.ManageError(err, common.StatusConditionTypeReconciled, instance)
@@ -506,12 +535,34 @@ func (r *ReconcileWebSphereLiberty) Reconcile(ctx context.Context, request ctrl.
 				}
 			}
 
-			if r.isLTPAKeySharingEnabled(instance) && len(ltpaSecretName) > 0 {
-				lutils.ConfigureLTPA(&statefulSet.Spec.Template, instance, OperatorShortName)
-				err := lutils.AddSecretResourceVersionAsEnvVar(&statefulSet.Spec.Template, instance, r.GetClient(), ltpaSecretName, "LTPA")
+			if r.isPasswordEncryptionKeySharingEnabled(instance) && len(encryptionSecretName) > 0 {
+				lutils.ConfigurePasswordEncryption(&statefulSet.Spec.Template, instance, OperatorShortName)
+				lastRotationAnnotation, err := lutils.GetSecretLastRotationAsLabelMap(instance, r.GetClient(), encryptionSecretName, PASSWORD_ENCRYPTION_RESOURCE_SHARING_FILE_NAME)
 				if err != nil {
 					return err
 				}
+				lutils.AddPodTemplateSpecAnnotation(&statefulSet.Spec.Template, lastRotationAnnotation)
+				if instance.Status.GetReferences()[lutils.GetTrackedResourceName(PASSWORD_ENCRYPTION_RESOURCE_SHARING_FILE_NAME)] != encryptionSecretName {
+					instance.Status.SetReference(lutils.GetTrackedResourceName(PASSWORD_ENCRYPTION_RESOURCE_SHARING_FILE_NAME), encryptionSecretName)
+				}
+			} else {
+				lutils.RemovePodTemplateSpecAnnotationByKey(&statefulSet.Spec.Template, lutils.GetLastRotationLabelKey(PASSWORD_ENCRYPTION_RESOURCE_SHARING_FILE_NAME))
+				lutils.RemoveMapElementByKey(instance.Status.GetReferences(), lutils.GetTrackedResourceName(PASSWORD_ENCRYPTION_RESOURCE_SHARING_FILE_NAME))
+			}
+
+			if r.isLTPAKeySharingEnabled(instance) && len(ltpaSecretName) > 0 {
+				lutils.ConfigureLTPA(&statefulSet.Spec.Template, instance, OperatorShortName, ltpaSecretName, ltpaMetadata.Name)
+				lastRotationAnnotation, err := lutils.GetSecretLastRotationAsLabelMap(instance, r.GetClient(), ltpaSecretName, LTPA_RESOURCE_SHARING_FILE_NAME)
+				if err != nil {
+					return err
+				}
+				lutils.AddPodTemplateSpecAnnotation(&statefulSet.Spec.Template, lastRotationAnnotation)
+				if instance.Status.GetReferences()[lutils.GetTrackedResourceName(LTPA_RESOURCE_SHARING_FILE_NAME)] != ltpaSecretName {
+					instance.Status.SetReference(lutils.GetTrackedResourceName(LTPA_RESOURCE_SHARING_FILE_NAME), ltpaSecretName)
+				}
+			} else {
+				lutils.RemovePodTemplateSpecAnnotationByKey(&statefulSet.Spec.Template, lutils.GetLastRotationLabelKey(LTPA_RESOURCE_SHARING_FILE_NAME))
+				lutils.RemoveMapElementByKey(instance.Status.GetReferences(), lutils.GetTrackedResourceName(LTPA_RESOURCE_SHARING_FILE_NAME))
 			}
 			return nil
 		})
@@ -574,12 +625,34 @@ func (r *ReconcileWebSphereLiberty) Reconcile(ctx context.Context, request ctrl.
 				}
 			}
 
-			if r.isLTPAKeySharingEnabled(instance) && len(ltpaSecretName) > 0 {
-				lutils.ConfigureLTPA(&deploy.Spec.Template, instance, OperatorShortName)
-				err := lutils.AddSecretResourceVersionAsEnvVar(&deploy.Spec.Template, instance, r.GetClient(), ltpaSecretName, "LTPA")
+			if r.isPasswordEncryptionKeySharingEnabled(instance) && len(encryptionSecretName) > 0 {
+				lutils.ConfigurePasswordEncryption(&deploy.Spec.Template, instance, OperatorShortName)
+				lastRotationAnnotation, err := lutils.GetSecretLastRotationAsLabelMap(instance, r.GetClient(), encryptionSecretName, PASSWORD_ENCRYPTION_RESOURCE_SHARING_FILE_NAME)
 				if err != nil {
 					return err
 				}
+				lutils.AddPodTemplateSpecAnnotation(&deploy.Spec.Template, lastRotationAnnotation)
+				if instance.Status.GetReferences()[lutils.GetTrackedResourceName(PASSWORD_ENCRYPTION_RESOURCE_SHARING_FILE_NAME)] != encryptionSecretName {
+					instance.Status.SetReference(lutils.GetTrackedResourceName(PASSWORD_ENCRYPTION_RESOURCE_SHARING_FILE_NAME), encryptionSecretName)
+				}
+			} else {
+				lutils.RemovePodTemplateSpecAnnotationByKey(&deploy.Spec.Template, lutils.GetLastRotationLabelKey(PASSWORD_ENCRYPTION_RESOURCE_SHARING_FILE_NAME))
+				lutils.RemoveMapElementByKey(instance.Status.GetReferences(), lutils.GetTrackedResourceName(PASSWORD_ENCRYPTION_RESOURCE_SHARING_FILE_NAME))
+			}
+
+			if r.isLTPAKeySharingEnabled(instance) && len(ltpaSecretName) > 0 {
+				lutils.ConfigureLTPA(&deploy.Spec.Template, instance, OperatorShortName, ltpaSecretName, ltpaMetadata.Name)
+				lastRotationAnnotation, err := lutils.GetSecretLastRotationAsLabelMap(instance, r.GetClient(), ltpaSecretName, LTPA_RESOURCE_SHARING_FILE_NAME)
+				if err != nil {
+					return err
+				}
+				lutils.AddPodTemplateSpecAnnotation(&deploy.Spec.Template, lastRotationAnnotation)
+				if instance.Status.GetReferences()[lutils.GetTrackedResourceName(LTPA_RESOURCE_SHARING_FILE_NAME)] != ltpaSecretName {
+					instance.Status.SetReference(lutils.GetTrackedResourceName(LTPA_RESOURCE_SHARING_FILE_NAME), ltpaSecretName)
+				}
+			} else {
+				lutils.RemovePodTemplateSpecAnnotationByKey(&deploy.Spec.Template, lutils.GetLastRotationLabelKey(LTPA_RESOURCE_SHARING_FILE_NAME))
+				lutils.RemoveMapElementByKey(instance.Status.GetReferences(), lutils.GetTrackedResourceName(LTPA_RESOURCE_SHARING_FILE_NAME))
 			}
 			return nil
 		})
@@ -842,6 +915,8 @@ func getMonitoringEnabledLabelName(ba common.BaseComponent) string {
 }
 
 func (r *ReconcileWebSphereLiberty) finalizeWebSphereLibertyApplication(reqLogger logr.Logger, wlapp *webspherelibertyv1.WebSphereLibertyApplication, pvcName string, pvcNamespace string) error {
+	r.RemoveLeaderTrackerReference(wlapp, LTPA_RESOURCE_SHARING_FILE_NAME)
+	r.RemoveLeaderTrackerReference(wlapp, PASSWORD_ENCRYPTION_RESOURCE_SHARING_FILE_NAME)
 	r.deletePVC(reqLogger, pvcName, pvcNamespace)
 	return nil
 }

--- a/internal/deploy/kubectl/websphereliberty-app-crd.yaml
+++ b/internal/deploy/kubectl/websphereliberty-app-crd.yaml
@@ -2562,6 +2562,10 @@ spec:
                 description: Enable management of LTPA key sharing amongst Liberty
                   containers. Defaults to false.
                 type: boolean
+              managePasswordEncryption:
+                description: Enable management of password encryption key sharing
+                  amongst Liberty containers. Defaults to false.
+                type: boolean
               manageTLS:
                 description: Enable management of TLS certificates. Defaults to true.
                 type: boolean

--- a/internal/deploy/kustomize/daily/base/websphere-liberty-crd.yaml
+++ b/internal/deploy/kustomize/daily/base/websphere-liberty-crd.yaml
@@ -2562,6 +2562,10 @@ spec:
                 description: Enable management of LTPA key sharing amongst Liberty
                   containers. Defaults to false.
                 type: boolean
+              managePasswordEncryption:
+                description: Enable management of password encryption key sharing
+                  amongst Liberty containers. Defaults to false.
+                type: boolean
               manageTLS:
                 description: Enable management of TLS certificates. Defaults to true.
                 type: boolean

--- a/utils/leader_tracker.go
+++ b/utils/leader_tracker.go
@@ -1,0 +1,314 @@
+/*
+  Copyright contributors to the WASdev project.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	wlv1 "github.com/WASdev/websphere-liberty-operator/api/v1"
+	"gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Leader tracking constants
+const ResourcesKey = "names"
+const ResourceOwnersKey = "owners"
+const ResourcePathsKey = "paths"
+const ResourcePathIndicesKey = "pathIndices"
+
+// const ResourceSubleasesKey = "subleases"
+
+const LibertyURI = "webspherelibertyapplications.liberty.websphere.ibm.com"
+const LeaderVersionLabel = LibertyURI + "/leader-version"
+const ResourcePathIndexLabel = LibertyURI + "/resource-path-index"
+
+const ResourceSuffixLength = 5
+
+func GetLastRotationLabelKey(sharedResourceName string) string {
+	return LibertyURI + "/" + sharedResourceName + "-last-rotation"
+}
+
+func GetTrackedResourceName(sharedResourceName string) string {
+	return kebabToCamelCase(sharedResourceName) + "TrackedResourceName"
+}
+
+type LeaderTracker struct {
+	Name      string
+	Owner     string
+	PathIndex string
+	Path      string
+	Sublease  string
+}
+
+type LeaderTrackerMetadata interface {
+	GetKind() string
+	GetAPIVersion() string
+	GetName() string
+	GetPath() string
+	GetPathIndex() string
+}
+
+func RemoveLeaderTracker(leaderTracker *[]LeaderTracker, i int) bool {
+	if leaderTracker == nil {
+		return false
+	}
+	if i >= len(*leaderTracker) {
+		return false
+	}
+	*leaderTracker = append((*leaderTracker)[:i], (*leaderTracker)[i+1:]...)
+	return true
+}
+
+func (tracker *LeaderTracker) RenewSublease() bool {
+	if tracker == nil {
+		return false
+	}
+	tracker.Sublease = fmt.Sprint(time.Now().Unix())
+	return true
+}
+
+func (tracker *LeaderTracker) SetOwner(instance string) bool {
+	if tracker == nil {
+		return false
+	}
+	tracker.Owner = instance
+	return true
+	// return tracker.RenewSublease()
+}
+
+// Clears the LeaderTracker owner if it matches instance, returning true if the LeaderTracker has changed and false otherwise
+func (tracker *LeaderTracker) ClearOwnerIfMatching(instance string) bool {
+	if tracker == nil {
+		return false
+	}
+	if tracker.Owner == instance {
+		tracker.Owner = ""
+		return true
+	}
+	return false
+}
+
+// Removes the Owner and Sublease attribute from LeaderTracker to indicate the resource is no longer being tracked
+func (tracker *LeaderTracker) EvictOwner() bool {
+	if tracker == nil {
+		return false
+	}
+	tracker.Owner = ""
+	// tracker.Sublease = ""
+	return true
+}
+
+func (tracker *LeaderTracker) EvictOwnerIfSubleaseHasExpired() bool {
+	if tracker == nil {
+		return false
+	}
+	// Evict if the sublease could not be parsed
+	then, err := strconv.ParseInt(tracker.Sublease, 10, 64)
+	if err != nil {
+		return tracker.EvictOwner()
+	}
+	// Evict if the sublease has surpassed the renew time
+	now := time.Now().Unix()
+	if now-then > 20 {
+		return tracker.EvictOwner()
+	}
+	return false
+}
+
+func InsertIntoSortedLeaderTrackers(leaderTrackers *[]LeaderTracker, newLeader *LeaderTracker) {
+	insertIndex := -1
+	for i, leader := range *leaderTrackers {
+		if strings.Compare(newLeader.Name, leader.Name) < 0 {
+			insertIndex = i
+		}
+	}
+	if insertIndex == -1 {
+		*leaderTrackers = append(*leaderTrackers, *newLeader)
+	} else {
+		*leaderTrackers = append(*leaderTrackers, LeaderTracker{})
+		copy((*leaderTrackers)[insertIndex+1:], (*leaderTrackers)[insertIndex:])
+		(*leaderTrackers)[insertIndex] = *newLeader
+	}
+}
+
+func CustomizeLeaderTracker(leaderTracker *corev1.Secret, trackerList *[]LeaderTracker) {
+	if trackerList == nil {
+		leaderTracker.Data = make(map[string][]byte)
+		leaderTracker.Data[ResourceOwnersKey] = []byte("")
+		leaderTracker.Data[ResourcesKey] = []byte("")
+		leaderTracker.Data[ResourcePathIndicesKey] = []byte("")
+		leaderTracker.Data[ResourcePathsKey] = []byte("")
+		// leaderTracker.Data[ResourceSubleasesKey] = []byte("")
+		return
+	}
+	leaderTracker.Data = make(map[string][]byte)
+	// owners, names, pathIndices, paths, subleases := "", "", "", "", ""
+	owners, names, pathIndices, paths := "", "", "", ""
+	n := len(*trackerList)
+	for i, tracker := range *trackerList {
+		owners += tracker.Owner
+		names += tracker.Name
+		pathIndices += tracker.PathIndex
+		paths += tracker.Path
+		// subleases += tracker.Sublease
+		if i < n-1 {
+			owners += ","
+			names += ","
+			pathIndices += ","
+			paths += ","
+			// subleases += ","
+		}
+	}
+	leaderTracker.Data[ResourceOwnersKey] = []byte(owners)
+	leaderTracker.Data[ResourcesKey] = []byte(names)
+	leaderTracker.Data[ResourcePathIndicesKey] = []byte(pathIndices)
+	leaderTracker.Data[ResourcePathsKey] = []byte(paths)
+	// leaderTracker.Data[ResourceSubleasesKey] = []byte(subleases)
+}
+
+func GetLeaderTracker(instance *wlv1.WebSphereLibertyApplication, operatorShortName string, leaderTrackerType string, client client.Client) (*corev1.Secret, *[]LeaderTracker, error) {
+	leaderTracker := &corev1.Secret{}
+	leaderTracker.Name = operatorShortName + "-managed-leader-tracking-" + leaderTrackerType
+	leaderTracker.Namespace = instance.GetNamespace()
+	leaderTracker.Labels = GetRequiredLabels(leaderTracker.Name, "")
+	if err := client.Get(context.TODO(), types.NamespacedName{Name: leaderTracker.Name, Namespace: leaderTracker.Namespace}, leaderTracker); err != nil {
+		// return a default leaderTracker
+		return leaderTracker, nil, err
+	}
+	// Create the LeaderTracker array
+	leaderTrackers := make([]LeaderTracker, 0)
+	owners, ownersFound := leaderTracker.Data[ResourceOwnersKey]
+	names, namesFound := leaderTracker.Data[ResourcesKey]
+	pathIndices, pathIndicesFound := leaderTracker.Data[ResourcePathIndicesKey]
+	paths, pathsFound := leaderTracker.Data[ResourcePathsKey]
+	// subleases, subleasesFound := leaderTracker.Data[ResourceSubleasesKey]
+	// If flags are out of sync, delete the leader tracker
+	if ownersFound != namesFound || pathIndicesFound != pathsFound || namesFound != pathIndicesFound { // || pathIndicesFound != subleasesFound {
+		if err := client.Delete(context.TODO(), leaderTracker); err != nil {
+			return nil, nil, err
+		}
+		return nil, nil, fmt.Errorf("the resource tracker is out of sync and has been deleted")
+	}
+	if len(owners) == 0 && len(names) == 0 && len(pathIndices) == 0 && len(paths) == 0 { // && len(subleases) == 0 {
+		return leaderTracker, &leaderTrackers, nil
+	}
+	ownersList := GetCommaSeparatedArray(string(owners))
+	namesList := GetCommaSeparatedArray(string(names))
+	pathIndicesList := GetCommaSeparatedArray(string(pathIndices))
+	pathsList := GetCommaSeparatedArray(string(paths))
+	// subleasesList := GetCommaSeparatedArray(string(subleases))
+	numOwners := len(ownersList)
+	numNames := len(namesList)
+	numPathIndices := len(pathIndicesList)
+	numPaths := len(pathsList)
+	// numSubleases := len(subleasesList)
+	// check for array length equivalence
+	if numOwners != numNames || numNames != numPathIndices || numPathIndices != numPaths { // || numPaths != numSubleases {
+		if err := client.Delete(context.TODO(), leaderTracker); err != nil {
+			return nil, nil, err
+		}
+		return nil, nil, fmt.Errorf("the resource tracker does not have array length equivalence and has been deleted")
+	}
+	// populate the leader trackers array
+	for i := range ownersList {
+		leaderTrackers = append(leaderTrackers, LeaderTracker{
+			Owner:     string(ownersList[i]),
+			Name:      string(namesList[i]),
+			PathIndex: string(pathIndicesList[i]),
+			Path:      string(pathsList[i]),
+			// Sublease:  string(subleasesList[i]),
+		})
+	}
+	return leaderTracker, &leaderTrackers, nil
+}
+
+func getUnstructuredResourceSignature(leaderTrackerType string, assetsPath *string) (map[string]interface{}, error) {
+	var folderPath string
+	if assetsPath != nil {
+		folderPath = *assetsPath
+	} else {
+		folderPath = "internal/controller/assets"
+	}
+	signature, err := os.ReadFile(folderPath + "/" + leaderTrackerType + "-signature.yaml")
+	if err != nil {
+		return nil, err
+	}
+	resourceSignatureYAML := make(map[string]interface{})
+	err = yaml.Unmarshal(signature, resourceSignatureYAML)
+	if err != nil {
+		return nil, err
+	}
+	return resourceSignatureYAML, nil
+}
+
+func CreateUnstructuredResourceFromSignature(leaderTrackerType string, assetsFolder *string, args ...string) (*unstructured.Unstructured, string, error) {
+	resourceSignatureYAML, err := getUnstructuredResourceSignature(leaderTrackerType, assetsFolder)
+	if err != nil {
+		return nil, "", err
+	}
+	apiVersion, apiVersionFound := resourceSignatureYAML["apiVersion"]
+	kind, kindFound := resourceSignatureYAML["kind"]
+	name, nameFound := resourceSignatureYAML["name"]
+	if !apiVersionFound || !kindFound || !nameFound {
+		return nil, "", fmt.Errorf("the operator bundled the shared resource '" + leaderTrackerType + "' with an invalid signature")
+	}
+	sharedResource := &unstructured.Unstructured{}
+	sharedResource.SetKind(kind.(string))
+	sharedResource.SetAPIVersion(apiVersion.(string))
+	sharedResourceName, err := parseUnstructuredResourceName(leaderTrackerType, name.(string), args...)
+	if err != nil {
+		return nil, "", err
+	}
+	return sharedResource, sharedResourceName, nil
+}
+
+func CreateUnstructuredResourceListFromSignature(leaderTrackerType string, assetsFolder *string, args ...string) (*unstructured.UnstructuredList, error) {
+	resourceSignatureYAML, err := getUnstructuredResourceSignature(leaderTrackerType, assetsFolder)
+	if err != nil {
+		return nil, err
+	}
+	apiVersion, apiVersionFound := resourceSignatureYAML["apiVersion"]
+	kind, kindFound := resourceSignatureYAML["kind"]
+	if !apiVersionFound || !kindFound {
+		return nil, fmt.Errorf("the operator bundled the shared resource '" + leaderTrackerType + "' with an invalid signature")
+	}
+	sharedResourceList := &unstructured.UnstructuredList{}
+	sharedResourceList.SetKind(kind.(string))
+	sharedResourceList.SetAPIVersion(apiVersion.(string))
+	return sharedResourceList, nil
+}
+
+// Returns the name of the unstructured resource from the leaderTrackerType signature by parsing and replacing string arguments in the args list
+func parseUnstructuredResourceName(leaderTrackerType string, nameStr string, args ...string) (string, error) {
+	for i, replacementString := range args {
+		replaceToken := fmt.Sprintf("{%d}", i)
+		if strings.Contains(nameStr, replaceToken) {
+			nameStr = strings.ReplaceAll(nameStr, replaceToken, replacementString)
+		} else {
+			return "", fmt.Errorf("the operator bundled the shared resource '" + leaderTrackerType + "' with an invalid signature; parseUnstructuredResourceName len(args) does not match the number of replacement tokens in the provided signature")
+		}
+	}
+	return nameStr, nil
+}

--- a/utils/leader_tracker_test.go
+++ b/utils/leader_tracker_test.go
@@ -1,0 +1,717 @@
+/*
+  Copyright contributors to the WASdev project.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	wlv1 "github.com/WASdev/websphere-liberty-operator/api/v1"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestCustomizeLeaderTrackerNil(t *testing.T) {
+	leaderTracker := &corev1.Secret{}
+	leaderTracker.Name = "leader-tracker-test"
+
+	CustomizeLeaderTracker(leaderTracker, nil)
+
+	expectedLeaderTrackerData := make(map[string][]byte)
+	expectedLeaderTrackerData[ResourceOwnersKey] = []byte("")
+	expectedLeaderTrackerData[ResourcesKey] = []byte("")
+	expectedLeaderTrackerData[ResourcePathIndicesKey] = []byte("")
+	expectedLeaderTrackerData[ResourcePathsKey] = []byte("")
+
+	tests := []Test{
+		{"nil leader tracker list", expectedLeaderTrackerData, leaderTracker.Data},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func TestCustomizeLeaderTrackerEmpty(t *testing.T) {
+	leaderTracker := &corev1.Secret{}
+	leaderTracker.Name = "leader-tracker-test"
+
+	trackerList := make([]LeaderTracker, 0)
+	CustomizeLeaderTracker(leaderTracker, &trackerList)
+
+	expectedLeaderTrackerData := make(map[string][]byte)
+	expectedLeaderTrackerData[ResourcesKey] = []byte("")
+	expectedLeaderTrackerData[ResourceOwnersKey] = []byte("")
+	expectedLeaderTrackerData[ResourcePathIndicesKey] = []byte("")
+	expectedLeaderTrackerData[ResourcePathsKey] = []byte("")
+
+	tests := []Test{
+		{"empty leader tracker list", expectedLeaderTrackerData, leaderTracker.Data},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func TestCustomizeLeaderTrackerSingle(t *testing.T) {
+	leaderTracker := &corev1.Secret{}
+	leaderTracker.Name = "leader-tracker-test"
+
+	ref1LeaderTracker := createMock1LeaderTracker()
+	trackerList := make([]LeaderTracker, 0)
+	trackerList = append(trackerList, createMock1LeaderTracker())
+
+	CustomizeLeaderTracker(leaderTracker, &trackerList)
+
+	expectedLeaderTrackerData := make(map[string][]byte)
+	expectedLeaderTrackerData[ResourcesKey] = []byte(ref1LeaderTracker.Name)
+	expectedLeaderTrackerData[ResourceOwnersKey] = []byte(ref1LeaderTracker.Owner)
+	expectedLeaderTrackerData[ResourcePathIndicesKey] = []byte(ref1LeaderTracker.PathIndex)
+	expectedLeaderTrackerData[ResourcePathsKey] = []byte(ref1LeaderTracker.Path)
+
+	tests := []Test{
+		{"single entry leader tracker", expectedLeaderTrackerData, leaderTracker.Data},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func TestCustomizeLeaderTrackerMultiple(t *testing.T) {
+	leaderTracker := &corev1.Secret{}
+	leaderTracker.Name = "leader-tracker-test"
+
+	ref1LeaderTracker, ref2LeaderTracker := createMock1LeaderTracker(), createMock2LeaderTracker()
+	trackerList := make([]LeaderTracker, 0)
+	trackerList = append(trackerList, createMock1LeaderTracker())
+	trackerList = append(trackerList, createMock2LeaderTracker())
+
+	CustomizeLeaderTracker(leaderTracker, &trackerList)
+
+	expectedLeaderTrackerData := make(map[string][]byte)
+	expectedLeaderTrackerData[ResourcesKey] = []byte(fmt.Sprintf("%s,%s", ref1LeaderTracker.Name, ref2LeaderTracker.Name))
+	expectedLeaderTrackerData[ResourceOwnersKey] = []byte(fmt.Sprintf("%s,%s", ref1LeaderTracker.Owner, ref2LeaderTracker.Owner))
+	expectedLeaderTrackerData[ResourcePathIndicesKey] = []byte(fmt.Sprintf("%s,%s", ref1LeaderTracker.PathIndex, ref2LeaderTracker.PathIndex))
+	expectedLeaderTrackerData[ResourcePathsKey] = []byte(fmt.Sprintf("%s,%s", ref1LeaderTracker.Path, ref2LeaderTracker.Path))
+
+	tests := []Test{
+		{"multiple entry leader tracker", expectedLeaderTrackerData, leaderTracker.Data},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	trackerList = trackerList[1:]
+	CustomizeLeaderTracker(leaderTracker, &trackerList)
+	expectedLeaderTrackerData[ResourcesKey] = []byte(ref2LeaderTracker.Name)
+	expectedLeaderTrackerData[ResourceOwnersKey] = []byte(ref2LeaderTracker.Owner)
+	expectedLeaderTrackerData[ResourcePathIndicesKey] = []byte(ref2LeaderTracker.PathIndex)
+	expectedLeaderTrackerData[ResourcePathsKey] = []byte(ref2LeaderTracker.Path)
+
+	tests = []Test{
+		{"remove entry leader tracker", expectedLeaderTrackerData, leaderTracker.Data},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+// func TestEvictOwnerIfSubleaseHasExpired(t *testing.T) {
+// 	leaderTracker, referenceLeaderTracker := createMock1LeaderTracker(), createMock1LeaderTracker()
+// 	changeDetected := leaderTracker.EvictOwnerIfSubleaseHasExpired()
+
+// 	tests := []Test{
+// 		{"evict owner if sublease has expired - change detected", true, changeDetected},
+// 		{"evict owner if sublease has expired - name unchanged", referenceLeaderTracker.Name, leaderTracker.Name},
+// 		{"evict owner if sublease has expired - owner evicted", "", leaderTracker.Owner},
+// 		{"evict owner if sublease has expired - path unchanged", referenceLeaderTracker.Path, leaderTracker.Path},
+// 		{"evict owner if sublease has expired - path index unchanged", referenceLeaderTracker.PathIndex, leaderTracker.PathIndex},
+// 		{"evict owner if sublease has expired - sublease removed", "", leaderTracker.Sublease},
+// 	}
+// 	if err := verifyTests(tests); err != nil {
+// 		t.Fatalf("%v", err)
+// 	}
+// }
+
+// func TestEvictOwnerIfSubleaseHasExpiredWithValidSublease(t *testing.T) {
+// 	leaderTracker, referenceLeaderTracker := createMock1LeaderTracker(), createMock1LeaderTracker()
+// 	leaderTracker.SetOwner("sublease-test")
+// 	sublease, subleaseErr := strconv.ParseInt(leaderTracker.Sublease, 10, 64)
+// 	now := time.Now().Unix()
+// 	timeDiff := sublease - now
+// 	changeDetected := leaderTracker.EvictOwnerIfSubleaseHasExpired()
+// 	nextSublease, nextSubleaseErr := strconv.ParseInt(leaderTracker.Sublease, 10, 64)
+
+// 	tests := []Test{
+// 		{"evict owner if sublease has expired with valid sublease - sublease can convert to int64", nil, subleaseErr},
+// 		{"evict owner if sublease has expired with valid sublease - sublease set in less than 20 seconds", true, timeDiff < 20},
+// 		{"evict owner if sublease has expired with valid sublease - next sublease can convert to int64", nil, nextSubleaseErr},
+// 		{"evict owner if sublease has expired with valid sublease - next sublease matches original sublease", sublease, nextSublease},
+// 		{"evict owner if sublease has expired with valid sublease - no change detected", false, changeDetected},
+// 		{"evict owner if sublease has expired with valid sublease - name unchanged", referenceLeaderTracker.Name, leaderTracker.Name},
+// 		{"evict owner if sublease has expired with valid sublease - owner set", "sublease-test", leaderTracker.Owner},
+// 		{"evict owner if sublease has expired with valid sublease - path unchanged", referenceLeaderTracker.Path, leaderTracker.Path},
+// 		{"evict owner if sublease has expired with valid sublease - path index unchanged", referenceLeaderTracker.PathIndex, leaderTracker.PathIndex},
+// 	}
+// 	if err := verifyTests(tests); err != nil {
+// 		t.Fatalf("%v", err)
+// 	}
+// }
+
+// func TestEvictOwnerIfSubleaseHasExpiredWithInvalidSublease(t *testing.T) {
+// 	leaderTracker, referenceLeaderTracker := createMock1LeaderTracker(), createMock1LeaderTracker()
+// 	leaderTracker.Sublease = "abc123" // when specifying an invalid sublease duration that can not be parsed into type int, the operator evicts the owner
+// 	changeDetected := leaderTracker.EvictOwnerIfSubleaseHasExpired()
+
+// 	tests := []Test{
+// 		{"evict owner if sublease has expired with invalid sublease - change detected", true, changeDetected},
+// 		{"evict owner if sublease has expired with invalid sublease - name unchanged", referenceLeaderTracker.Name, leaderTracker.Name},
+// 		{"evict owner if sublease has expired with invalid sublease - owner evicted", "", leaderTracker.Owner},
+// 		{"evict owner if sublease has expired with invalid sublease - path unchanged", referenceLeaderTracker.Path, leaderTracker.Path},
+// 		{"evict owner if sublease has expired with invalid sublease - path index unchanged", referenceLeaderTracker.PathIndex, leaderTracker.PathIndex},
+// 		{"evict owner if sublease has expired with invalid sublease - sublease removed", "", leaderTracker.Sublease},
+// 	}
+// 	if err := verifyTests(tests); err != nil {
+// 		t.Fatalf("%v", err)
+// 	}
+// }
+
+func TestClearOwnerIfMatching(t *testing.T) {
+	leaderTracker, referenceLeaderTracker := createMock1LeaderTracker(), createMock1LeaderTracker()
+	leaderTracker.Owner = "test-3"
+	changeDetected := leaderTracker.ClearOwnerIfMatching(referenceLeaderTracker.Owner)
+
+	tests := []Test{
+		{"clear owner if matching - no change detected", false, changeDetected},
+		{"clear owner if matching - name unchanged", referenceLeaderTracker.Name, leaderTracker.Name},
+		{"clear owner if matching - owner unchanged", "test-3", leaderTracker.Owner},
+		{"clear owner if matching - path unchanged", referenceLeaderTracker.Path, leaderTracker.Path},
+		{"clear owner if matching - path index unchanged", referenceLeaderTracker.PathIndex, leaderTracker.PathIndex},
+		{"clear owner if matching - sublease unchanged", referenceLeaderTracker.Sublease, leaderTracker.Sublease},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	referenceLeaderTracker.Owner = leaderTracker.Owner
+	changeDetected = leaderTracker.ClearOwnerIfMatching(referenceLeaderTracker.Owner)
+
+	tests = []Test{
+		{"clear owner if matching - change detected", true, changeDetected},
+		{"clear owner if matching - name unchanged", referenceLeaderTracker.Name, leaderTracker.Name},
+		{"clear owner if matching - owner removed", "", leaderTracker.Owner},
+		{"clear owner if matching - path unchanged", referenceLeaderTracker.Path, leaderTracker.Path},
+		{"clear owner if matching - path index unchanged", referenceLeaderTracker.PathIndex, leaderTracker.PathIndex},
+		{"clear owner if matching - sublease unchanged", referenceLeaderTracker.Sublease, leaderTracker.Sublease},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func TestSetOwner(t *testing.T) {
+	leaderTracker, referenceLeaderTracker := createMock1LeaderTracker(), createMock1LeaderTracker()
+	changeDetected := leaderTracker.SetOwner("new-owner-name")
+	// currTime, currErr := strconv.ParseInt(leaderTracker.Sublease, 10, 64)
+	tests := []Test{
+		{"set owner - change detected", true, changeDetected},
+		{"set owner - name unchanged", referenceLeaderTracker.Name, leaderTracker.Name},
+		{"set owner - owner changed", "new-owner-name", leaderTracker.Owner},
+		{"set owner - path unchanged", referenceLeaderTracker.Path, leaderTracker.Path},
+		{"set owner - path index unchanged", referenceLeaderTracker.PathIndex, leaderTracker.PathIndex},
+		// {"set owner - sublease converts to int64 without error", nil, currErr},
+		// {"set owner - new sublease time greater or equal to current time", true, currTime >= time.Now().Unix()},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func TestRemoveLeaderTracker(t *testing.T) {
+	leaderTracker1 := createMock1LeaderTracker()
+	leaderTracker2, ref2LeaderTracker := createMock2LeaderTracker(), createMock2LeaderTracker()
+	leaderTrackerList := []LeaderTracker{
+		leaderTracker1,
+		leaderTracker2,
+		leaderTracker1,
+	}
+	changeDetected := RemoveLeaderTracker(&leaderTrackerList, 3)
+
+	tests := []Test{
+		{"remove leader tracker, out of bounds - no change detected", false, changeDetected},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	changeDetected = RemoveLeaderTracker(&leaderTrackerList, 2)
+
+	tests = []Test{
+		{"remove leader tracker, remove last element - change detected", true, changeDetected},
+		{"remove leader tracker, remove last element - length check", 2, len(leaderTrackerList)},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	changeDetected = RemoveLeaderTracker(&leaderTrackerList, 0)
+
+	tests = []Test{
+		{"remove leader tracker, remove first element - change detected", true, changeDetected},
+		{"remove leader tracker, remove first element - length check", 1, len(leaderTrackerList)},
+		{"remove leader tracker, remove first element", ref2LeaderTracker.Name, leaderTrackerList[0].Name},
+		{"remove leader tracker, remove first element", ref2LeaderTracker.Owner, leaderTrackerList[0].Owner},
+		{"remove leader tracker, remove first element", ref2LeaderTracker.Path, leaderTrackerList[0].Path},
+		{"remove leader tracker, remove first element", ref2LeaderTracker.PathIndex, leaderTrackerList[0].PathIndex},
+		{"remove leader tracker, remove first element", ref2LeaderTracker.Sublease, leaderTrackerList[0].Sublease},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	changeDetected = RemoveLeaderTracker(&leaderTrackerList, 0)
+
+	tests = []Test{
+		{"remove leader tracker, remove first element - change detected", true, changeDetected},
+		{"remove leader tracker, remove first element - length check", 0, len(leaderTrackerList)},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	changeDetected = RemoveLeaderTracker(&leaderTrackerList, 0)
+
+	tests = []Test{
+		{"remove leader tracker, remove first element - no change detected", false, changeDetected},
+		{"remove leader tracker, remove first element - length check", 0, len(leaderTrackerList)},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	changeDetected = RemoveLeaderTracker(nil, 0)
+
+	tests = []Test{
+		{"remove leader tracker, nil array - no change detected", false, changeDetected},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func TestGetLeaderTrackerWithoutSecret(t *testing.T) {
+	spec := wlv1.WebSphereLibertyApplicationSpec{}
+
+	// Create Liberty app
+	instance := createWebSphereLibertyApp(name, namespace, spec)
+
+	// Create client
+	objs, s := []runtime.Object{instance}, scheme.Scheme
+	s.AddKnownTypes(wlv1.GroupVersion, instance)
+	cl := fakeclient.NewFakeClient(objs...)
+
+	var referenceLeaderTrackers *[]LeaderTracker
+	leaderTrackerSecret, leaderTrackers, err := GetLeaderTracker(instance, "wlo", "ltpa", cl)
+	tests := []Test{
+		{"get leader tracker without secret - secret name matches", "wlo-managed-leader-tracking-ltpa", leaderTrackerSecret.Name},
+		{"get leader tracker without secret - leaderTrackers is nil", referenceLeaderTrackers, leaderTrackers},
+		{"get leader tracker without secret - resource not found", true, kerrors.IsNotFound(err)},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func TestGetLeaderTrackerWithEmptySecret(t *testing.T) {
+	spec := wlv1.WebSphereLibertyApplicationSpec{}
+
+	// Create Liberty app
+	instance := createWebSphereLibertyApp(name, namespace, spec)
+
+	// Create client
+	objs, s := []runtime.Object{instance}, scheme.Scheme
+	s.AddKnownTypes(wlv1.GroupVersion, instance)
+	cl := fakeclient.NewFakeClient(objs...)
+
+	// Create empty secret
+	emptySecret := &corev1.Secret{}
+	emptySecret.Name = "wlo-managed-leader-tracking-ltpa"
+	emptySecret.Namespace = namespace
+	createEmptySecretErr := cl.Create(context.TODO(), emptySecret)
+
+	_, leaderTrackers, err := GetLeaderTracker(instance, "wlo", "ltpa", cl)
+	tests := []Test{
+		{"get leader tracker with empty secret - create empty secret without error", nil, createEmptySecretErr},
+		{"get leader tracker with empty secret - no error", nil, err},
+		{"get leader tracker with empty secret - leaderTrackers empty", 0, len(*leaderTrackers)},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func TestGetLeaderTrackerWithOneSecretEntry(t *testing.T) {
+	spec := wlv1.WebSphereLibertyApplicationSpec{}
+
+	// Create Liberty app
+	instance := createWebSphereLibertyApp(name, namespace, spec)
+
+	// Create client
+	objs, s := []runtime.Object{instance}, scheme.Scheme
+	s.AddKnownTypes(wlv1.GroupVersion, instance)
+	cl := fakeclient.NewFakeClient(objs...)
+
+	// Create one secret entry
+	oneSecret := &corev1.Secret{}
+	oneSecret.Name = "wlo-managed-leader-tracking-ltpa"
+	oneSecret.Namespace = namespace
+	mockLeaderTracker := createMock1LeaderTracker()
+	oneSecret.Data = make(map[string][]byte)
+	oneSecret.Data[ResourcesKey] = []byte(mockLeaderTracker.Name)
+	oneSecret.Data[ResourceOwnersKey] = []byte(mockLeaderTracker.Owner)
+	oneSecret.Data[ResourcePathIndicesKey] = []byte(mockLeaderTracker.PathIndex)
+	oneSecret.Data[ResourcePathsKey] = []byte(mockLeaderTracker.Path)
+	// oneSecret.Data[ResourceSubleasesKey] = []byte(mockLeaderTracker.Sublease)
+	createOneSecretErr := cl.Create(context.TODO(), oneSecret)
+
+	_, leaderTrackers, err := GetLeaderTracker(instance, "wlo", "ltpa", cl)
+	tests := []Test{
+		{"get leader tracker with one secret entry - create secret without error", nil, createOneSecretErr},
+		{"get leader tracker with one secret entry - no error", nil, err},
+		{"get leader tracker with one secret entry - leaderTrackers empty", 1, len(*leaderTrackers)},
+		{"get leader tracker with one secret entry - name unchanged", mockLeaderTracker.Name, (*leaderTrackers)[0].Name},
+		{"get leader tracker with one secret entry - owner unchanged", mockLeaderTracker.Owner, (*leaderTrackers)[0].Owner},
+		{"get leader tracker with one secret entry - path index unchanged", mockLeaderTracker.PathIndex, (*leaderTrackers)[0].PathIndex},
+		{"get leader tracker with one secret entry - path unchanged", mockLeaderTracker.Path, (*leaderTrackers)[0].Path},
+		// {"get leader tracker with one secret entry - sublease unchanged", mockLeaderTracker.Sublease, (*leaderTrackers)[0].Sublease},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func TestGetLeaderTrackerWithOneSecretEntryWithMissingKey(t *testing.T) {
+	spec := wlv1.WebSphereLibertyApplicationSpec{}
+
+	// Create Liberty app
+	instance := createWebSphereLibertyApp(name, namespace, spec)
+
+	// Create client
+	objs, s := []runtime.Object{instance}, scheme.Scheme
+	s.AddKnownTypes(wlv1.GroupVersion, instance)
+	cl := fakeclient.NewFakeClient(objs...)
+
+	// Create one secret entry
+	oneSecret := &corev1.Secret{}
+	oneSecret.Name = "wlo-managed-leader-tracking-ltpa"
+	oneSecret.Namespace = namespace
+	mockLeaderTracker := createMock1LeaderTracker()
+	oneSecret.Data = make(map[string][]byte)
+	oneSecret.Data[ResourcesKey] = []byte(mockLeaderTracker.Name)
+	oneSecret.Data[ResourceOwnersKey] = []byte(mockLeaderTracker.Owner)
+	oneSecret.Data[ResourcePathIndicesKey] = []byte(mockLeaderTracker.PathIndex)
+	// oneSecret.Data[ResourcePathsKey] = []byte(mockLeaderTracker.Path) // remove path key
+	createOneSecretErr := cl.Create(context.TODO(), oneSecret)
+	_, leaderTrackers, err := GetLeaderTracker(instance, "wlo", "ltpa", cl)
+
+	// GetLeaderTracker should delete the secret
+	checkOneSecret := &corev1.Secret{}
+	checkOneSecret.Name = "wlo-managed-leader-tracking-ltpa"
+	checkOneSecret.Namespace = namespace
+
+	var nilLeaderTrackers *[]LeaderTracker
+	checkOneSecretError := cl.Get(context.TODO(), types.NamespacedName{Name: checkOneSecret.Name, Namespace: checkOneSecret.Namespace}, checkOneSecret)
+	tests := []Test{
+		{"get leader tracker with one secret entry and missing key - create secret without error", nil, createOneSecretErr},
+		{"get leader tracker with one secret entry and missing key - errors", false, err == nil},
+		{"get leader tracker with one secret entry and missing key - leader tracker invalid", nilLeaderTrackers, leaderTrackers},
+		{"get leader tracker with one secret entry and missing key - secret deleted", true, kerrors.IsNotFound(checkOneSecretError)},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func TestGetLeaderTrackerWithTwoSecretEntries(t *testing.T) {
+	spec := wlv1.WebSphereLibertyApplicationSpec{}
+
+	// Create Liberty app
+	instance := createWebSphereLibertyApp(name, namespace, spec)
+
+	// Create client
+	objs, s := []runtime.Object{instance}, scheme.Scheme
+	s.AddKnownTypes(wlv1.GroupVersion, instance)
+	cl := fakeclient.NewFakeClient(objs...)
+
+	// Create two secret entries
+	twoSecret := &corev1.Secret{}
+	twoSecret.Name = "wlo-managed-leader-tracking-ltpa"
+	twoSecret.Namespace = namespace
+	mock1LeaderTracker, mock2LeaderTracker := createMock1LeaderTracker(), createMock2LeaderTracker()
+	twoSecret.Data = make(map[string][]byte)
+	twoSecret.Data[ResourcesKey] = []byte(fmt.Sprintf("%s,%s", mock1LeaderTracker.Name, mock2LeaderTracker.Name))
+	twoSecret.Data[ResourceOwnersKey] = []byte(fmt.Sprintf("%s,%s", mock1LeaderTracker.Owner, mock2LeaderTracker.Owner))
+	twoSecret.Data[ResourcePathIndicesKey] = []byte(fmt.Sprintf("%s,%s", mock1LeaderTracker.PathIndex, mock2LeaderTracker.PathIndex))
+	twoSecret.Data[ResourcePathsKey] = []byte(fmt.Sprintf("%s,%s", mock1LeaderTracker.Path, mock2LeaderTracker.Path))
+	// twoSecret.Data[ResourceSubleasesKey] = []byte(fmt.Sprintf("%s,%s", mock1LeaderTracker.Sublease, mock2LeaderTracker.Sublease))
+	createTwoSecretErr := cl.Create(context.TODO(), twoSecret)
+	_, leaderTrackers, err := GetLeaderTracker(instance, "wlo", "ltpa", cl)
+
+	tests := []Test{
+		{"get leader tracker with two secret entries - create secret without error", nil, createTwoSecretErr},
+		{"get leader tracker with two secret entries - errors", nil, err},
+		{"get leader tracker with two secret entries - leader tracker length", 2, len(*leaderTrackers)},
+		{"get leader tracker with two secret entries - (1) name unchanged", mock1LeaderTracker.Name, (*leaderTrackers)[0].Name},
+		{"get leader tracker with two secret entries - (1) owner unchanged", mock1LeaderTracker.Owner, (*leaderTrackers)[0].Owner},
+		{"get leader tracker with two secret entries - (1) path index unchanged", mock1LeaderTracker.PathIndex, (*leaderTrackers)[0].PathIndex},
+		{"get leader tracker with two secret entries - (1) path unchanged", mock1LeaderTracker.Path, (*leaderTrackers)[0].Path},
+		// {"get leader tracker with two secret entries - (1) sublease unchanged", mock1LeaderTracker.Sublease, (*leaderTrackers)[0].Sublease},
+		{"get leader tracker with two secret entries - (2) name unchanged", mock2LeaderTracker.Name, (*leaderTrackers)[1].Name},
+		{"get leader tracker with two secret entries - (2) owner unchanged", mock2LeaderTracker.Owner, (*leaderTrackers)[1].Owner},
+		{"get leader tracker with two secret entries - (2) path index unchanged", mock2LeaderTracker.PathIndex, (*leaderTrackers)[1].PathIndex},
+		{"get leader tracker with two secret entries - (2) path unchanged", mock2LeaderTracker.Path, (*leaderTrackers)[1].Path},
+		// {"get leader tracker with two secret entries - (2) sublease unchanged", mock2LeaderTracker.Sublease, (*leaderTrackers)[1].Sublease},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func TestGetLeaderTrackerWithTwoSecretEntriesAndMissingEntry(t *testing.T) {
+	spec := wlv1.WebSphereLibertyApplicationSpec{}
+
+	// Create Liberty app
+	instance := createWebSphereLibertyApp(name, namespace, spec)
+
+	// Create client
+	objs, s := []runtime.Object{instance}, scheme.Scheme
+	s.AddKnownTypes(wlv1.GroupVersion, instance)
+	cl := fakeclient.NewFakeClient(objs...)
+
+	// Create two secret entries
+	twoSecret := &corev1.Secret{}
+	twoSecret.Name = "wlo-managed-leader-tracking-ltpa"
+	twoSecret.Namespace = namespace
+	mock1LeaderTracker, mock2LeaderTracker := createMock1LeaderTracker(), createMock2LeaderTracker()
+	twoSecret.Data = make(map[string][]byte)
+	twoSecret.Data[ResourcesKey] = []byte(fmt.Sprintf("%s,%s", mock1LeaderTracker.Name, mock2LeaderTracker.Name))
+	twoSecret.Data[ResourceOwnersKey] = []byte(fmt.Sprintf("%s,%s", mock1LeaderTracker.Owner, mock2LeaderTracker.Owner))
+	twoSecret.Data[ResourcePathIndicesKey] = []byte(fmt.Sprintf("%s,%s", mock1LeaderTracker.PathIndex, mock2LeaderTracker.PathIndex))
+	// twoSecret.Data[ResourcePathsKey] = []byte(fmt.Sprintf("%s,%s", mock1LeaderTracker.Path, mock2LeaderTracker.Path)) // missing mock2LeaderTracker.Sublease
+	createTwoSecretErr := cl.Create(context.TODO(), twoSecret)
+	_, leaderTrackers, err := GetLeaderTracker(instance, "wlo", "ltpa", cl)
+
+	// GetLeaderTracker should delete the secret
+	checkTwoSecret := &corev1.Secret{}
+	checkTwoSecret.Name = "wlo-managed-leader-tracking-ltpa"
+	checkTwoSecret.Namespace = namespace
+
+	var nilLeaderTrackers *[]LeaderTracker
+	checkTwoSecretError := cl.Get(context.TODO(), types.NamespacedName{Name: checkTwoSecret.Name, Namespace: checkTwoSecret.Namespace}, checkTwoSecret)
+	tests := []Test{
+		{"get leader tracker with two secret entries and missing entry - create secret without error", nil, createTwoSecretErr},
+		{"get leader tracker with two secret entries and missing entry - error is not nil", false, err == nil},
+		{"get leader tracker with two secret entries and missing entry - leader tracker invalid", nilLeaderTrackers, leaderTrackers},
+		{"get leader tracker with two secret entries and missing entry - secret does not exist", true, kerrors.IsNotFound(checkTwoSecretError)},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func Test_getUnstructuredResourceSignature(t *testing.T) {
+	assetsFolder := getAssetsFolder()
+	unstructuredResource, err := getUnstructuredResourceSignature("ltpa", &assetsFolder)
+	_, hasKind := unstructuredResource["kind"]
+	_, hasAPIVersion := unstructuredResource["apiVersion"]
+	tests := []Test{
+		{"get unstructured resource signature - get without error", nil, err},
+		{"get unstructured resource signature - unstructured resource has kind", true, hasKind},
+		{"get unstructured resource signature - unstructured resource has api version", true, hasAPIVersion},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func Test_getUnstructuredResourceSignatureWithInvalidSignature(t *testing.T) {
+	testsFolder := getTestsFolder()
+	_, err := getUnstructuredResourceSignature("invalid-wlo", &testsFolder)
+	tests := []Test{
+		{"get unstructured resource signature, invalid YAML - get with error", false, err == nil},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func Test_getUnstructuredResourceSignatureWithMissingSignature(t *testing.T) {
+	testsFolder := getTestsFolder()
+	_, err := getUnstructuredResourceSignature("missing-wlo", &testsFolder)
+	tests := []Test{
+		{"get unstructured resource signature, missing YAML - get with error", false, err == nil},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func TestCreateUnstructuredResourceFromSignature(t *testing.T) {
+	testsFolder := getTestsFolder()
+	unstructuredLibertyApp, unstructuredLibertyAppName, err := CreateUnstructuredResourceFromSignature("wlo", &testsFolder, "wlo")
+	tests := []Test{
+		{"create unstructured resource from signature - no error", nil, err},
+		{"create unstructured resource from signature - liberty app kind ", "WebSphereLibertyApplication", unstructuredLibertyApp.GetKind()},
+		{"create unstructured resource from signature - liberty app API version", "liberty.websphere.ibm.com/v1", unstructuredLibertyApp.GetAPIVersion()},
+		{"create unstructured resource from signature - liberty app name", "wlo-managed-wlapp", unstructuredLibertyAppName},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func TestCreateUnstructuredResourceFromSignatureWithInvalidSignature(t *testing.T) {
+	testsFolder := getTestsFolder()
+	unstructuredLibertyApp, unstructuredLibertyAppName, err := CreateUnstructuredResourceFromSignature("invalid-wlo", &testsFolder, "wlo")
+	var nilUnstructuredLibertyApp *unstructured.Unstructured
+	tests := []Test{
+		{"create unstructured resource from signature, invalid YAML - has error", false, err == nil},
+		{"create unstructured resource from signature, invalid YAML - liberty app is nil", nilUnstructuredLibertyApp, unstructuredLibertyApp},
+		{"create unstructured resource from signature, invalid YAML - liberty app name empty", "", unstructuredLibertyAppName},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// check when more arguments are provided than replacement tokens in wlo-signature.yaml
+	unstructuredLibertyApp, unstructuredLibertyAppName, err = CreateUnstructuredResourceFromSignature("wlo", &testsFolder, "wlo", "one", "two", "three", "four")
+	tests = []Test{
+		{"create unstructured resource from signature, invalid name replacement 1 - has error", false, err == nil},
+		{"create unstructured resource from signature, invalid name replacement 1 - liberty app is nil", nilUnstructuredLibertyApp, unstructuredLibertyApp},
+		{"create unstructured resource from signature, invalid name replacement 1 - liberty app name empty", "", unstructuredLibertyAppName},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// check when less arguments are provided than replacement tokens in wlo-signature.yaml
+	unstructuredLibertyApp, unstructuredLibertyAppName, err = CreateUnstructuredResourceFromSignature("invalid", &testsFolder)
+	tests = []Test{
+		{"create unstructured resource from signature, invalid name replacement 2 - has error", false, err == nil},
+		{"create unstructured resource from signature, invalid name replacement 2 - liberty app is nil", nilUnstructuredLibertyApp, unstructuredLibertyApp},
+		{"create unstructured resource from signature, invalid name replacement 2 - liberty app name empty", "", unstructuredLibertyAppName},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func TestCreateUnstructuredResourceListFromSignature(t *testing.T) {
+	testsFolder := getTestsFolder()
+	unstructuredLibertyAppList, err := CreateUnstructuredResourceListFromSignature("wlo", &testsFolder, "wlo")
+	tests := []Test{
+		{"create unstructured resource list from signature - no error", nil, err},
+		{"create unstructured resource list from signature - liberty app list kind ", "WebSphereLibertyApplication", unstructuredLibertyAppList.GetKind()},
+		{"create unstructured resource list from signature - liberty app list API version", "liberty.websphere.ibm.com/v1", unstructuredLibertyAppList.GetAPIVersion()},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func TestCreateUnstructuredResourceListFromSignatureWithInvalidSignature(t *testing.T) {
+	testsFolder := getTestsFolder()
+	unstructuredLibertyAppList, err := CreateUnstructuredResourceListFromSignature("invalid-wlo", &testsFolder, "wlo")
+	var nilUnstructuredLibertyAppList *unstructured.UnstructuredList
+	tests := []Test{
+		{"create unstructured resource list from signature, invalid YAML - has error", false, err == nil},
+		{"create unstructured resource list from signature, invalid YAML - liberty app is nil", nilUnstructuredLibertyAppList, unstructuredLibertyAppList},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func TestCreateUnstructuredResourceFromSignatureWithUserError(t *testing.T) {
+	testsFolder := getTestsFolder()
+	unstructuredLibertyApp, unstructuredLibertyAppName, err := CreateUnstructuredResourceFromSignature("user-error-wlo", &testsFolder)
+	var nilUnstructuredLibertyApp *unstructured.Unstructured
+	tests := []Test{
+		{"create unstructured resource from signature, invalid YAML - has error", false, err == nil},
+		{"create unstructured resource from signature, invalid YAML - liberty app is nil", nilUnstructuredLibertyApp, unstructuredLibertyApp},
+		{"create unstructured resource from signature, invalid YAML - liberty app name empty", "", unstructuredLibertyAppName},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func TestCreateUnstructuredResourceListFromSignatureWithUserError(t *testing.T) {
+	testsFolder := getTestsFolder()
+	unstructuredLibertyAppList, err := CreateUnstructuredResourceListFromSignature("user-error-wlo", &testsFolder)
+	var nilUnstructuredLibertyAppList *unstructured.UnstructuredList
+	tests := []Test{
+		{"create unstructured resource from signature, invalid YAML - has error", false, err == nil},
+		{"create unstructured resource from signature, invalid YAML - liberty app is nil", nilUnstructuredLibertyAppList, unstructuredLibertyAppList},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func getUtilsFolder() string {
+	cwd, err := os.Getwd()
+	if err != nil || !strings.HasSuffix(cwd, "/utils") {
+		return "utils"
+	}
+	return cwd
+}
+
+func getAssetsFolder() string {
+	return getUtilsFolder() + "/../internal/controller/assets"
+}
+
+func getTestsFolder() string {
+	return getUtilsFolder() + "/../internal/controller/tests"
+}
+
+func createMock1LeaderTracker() LeaderTracker {
+	return LeaderTracker{
+		Name:      "-12345",
+		Owner:     "test",
+		Path:      "v1_0_0.hello.world",
+		PathIndex: "v1_0_0.0",
+		Sublease:  "0",
+	}
+}
+
+func createMock2LeaderTracker() LeaderTracker {
+	return LeaderTracker{
+		Name:      "-67890",
+		Owner:     "test-2",
+		Path:      "v1_0_0.hello.world",
+		PathIndex: "v1_0_0.1",
+		Sublease:  "0",
+	}
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -20,6 +20,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math/rand/v2"
+	"os"
 	"reflect"
 	"sort"
 	"strconv"
@@ -51,11 +53,26 @@ var log = logf.Log.WithName("websphereliberty_utils")
 const serviceabilityMountPath = "/serviceability"
 const ssoEnvVarPrefix = "SEC_SSO_"
 const OperandVersion = "1.4.0"
-const ltpaKeysMountPath = "/config/managedLTPA"
-const ltpaServerXMLOverridesMountPath = "/config/configDropins/overrides/"
+
+// LTPA constants
+const managedLTPAMountPath = "/config/managedLTPA"
 const LTPAServerXMLSuffix = "-managed-ltpa-server-xml"
-const ltpaKeysFileName = "ltpa.keys"
-const ltpaXMLFileName = "managedLTPA.xml"
+const LTPAServerXMLMountSuffix = "-managed-ltpa-mount-server-xml"
+const LTPAKeysFileName = "ltpa.keys"
+const LTPAKeysXMLFileName = "managedLTPA.xml"
+const LTPAKeysMountXMLFileName = "managedLTPAMount.xml"
+const LTPAKeysCreationScriptFileName = "create_ltpa_keys.sh"
+
+// Mount constants
+const SecureMountPath = "/output/resources/liberty-operator"
+const overridesMountPath = "/config/configDropins/overrides"
+
+// Password encryption constants
+const ManagedEncryptionServerXML = "-managed-encryption-server-xml"
+const ManagedEncryptionMountServerXML = "-managed-encryption-mount-server-xml"
+const PasswordEncryptionKeyRootName = "wlp-password-encryption-key"
+const EncryptionKeyXMLFileName = "encryptionKey.xml"
+const EncryptionKeyMountXMLFileName = "encryptionKeyMount.xml"
 
 const (
 	productChargedContainersKey string = "productChargedContainers"
@@ -79,6 +96,66 @@ var entitlementCloudPakID = map[wlv1.LicenseEntitlement]string{
 	wlv1.LicenseEntitlementWSHE:            "6358611af04743f99f42dadcd6e39d52",
 	wlv1.LicenseEntitlementFamilyEdition:   "be8ae84b3dd04d81b90af0d846849182",
 	wlv1.LicenseEntitlementCP4Apps:         "4df52d2cdc374ba09f631a650ad2b5bf",
+}
+
+type LTPAMetadata struct {
+	Kind       string
+	APIVersion string
+	Name       string
+	Path       string
+	PathIndex  string
+}
+
+func (m LTPAMetadata) GetName() string {
+	return m.Name
+}
+func (m LTPAMetadata) GetPath() string {
+	return m.Path
+}
+func (m LTPAMetadata) GetPathIndex() string {
+	return m.PathIndex
+}
+func (m LTPAMetadata) GetKind() string {
+	return m.Kind
+}
+func (m LTPAMetadata) GetAPIVersion() string {
+	return m.APIVersion
+}
+
+type PasswordEncryptionMetadata struct {
+	Kind       string
+	APIVersion string
+	Name       string
+	Path       string
+	PathIndex  string
+}
+
+func (m PasswordEncryptionMetadata) GetName() string {
+	return m.Name
+}
+func (m PasswordEncryptionMetadata) GetPath() string {
+	return m.Path
+}
+func (m PasswordEncryptionMetadata) GetPathIndex() string {
+	return m.PathIndex
+}
+func (m PasswordEncryptionMetadata) GetKind() string {
+	return m.Kind
+}
+func (m PasswordEncryptionMetadata) GetAPIVersion() string {
+	return m.APIVersion
+}
+
+type LTPAConfig struct {
+	Metadata                    *LTPAMetadata
+	SecretName                  string
+	SecretInstanceName          string
+	ServiceAccountName          string
+	JobRequestConfigMapName     string
+	ConfigMapName               string
+	FileName                    string
+	EncryptionKeySecretName     string
+	EncryptionKeySharingEnabled bool // true or false
 }
 
 // Validate if the WebSpherLibertyApplication is valid
@@ -190,6 +267,17 @@ func CustomizeLibertyEnv(pts *corev1.PodTemplateSpec, la *wlv1.WebSphereLibertyA
 	return nil
 }
 
+func GetSecretLastRotationAsLabelMap(la *wlv1.WebSphereLibertyApplication, client client.Client, secretName string, sharedResourceName string) (map[string]string, error) {
+	secret := &corev1.Secret{}
+	err := client.Get(context.TODO(), types.NamespacedName{Name: secretName, Namespace: la.GetNamespace()}, secret)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Secret %q was not found in namespace %q", secretName, la.GetNamespace())
+	}
+	return map[string]string{
+		GetLastRotationLabelKey(sharedResourceName): string(secret.Data["lastRotation"]),
+	}, nil
+}
+
 func AddSecretResourceVersionAsEnvVar(pts *corev1.PodTemplateSpec, la *wlv1.WebSphereLibertyApplication, client client.Client, secretName string, envNamePrefix string) error {
 	secret := &corev1.Secret{}
 	err := client.Get(context.TODO(), types.NamespacedName{Name: secretName, Namespace: la.GetNamespace()}, secret)
@@ -202,11 +290,25 @@ func AddSecretResourceVersionAsEnvVar(pts *corev1.PodTemplateSpec, la *wlv1.WebS
 	return nil
 }
 
+func RemovePodTemplateSpecAnnotationByKey(pts *corev1.PodTemplateSpec, annotationKey string) {
+	RemoveMapElementByKey(pts.Annotations, annotationKey)
+}
+
+func RemoveMapElementByKey(refMap map[string]string, labelKey string) {
+	if _, found := refMap[labelKey]; found {
+		delete(refMap, labelKey)
+	}
+}
+
+func AddPodTemplateSpecAnnotation(pts *corev1.PodTemplateSpec, annotation map[string]string) {
+	pts.Annotations = rcoutils.MergeMaps(pts.Annotations, annotation)
+}
+
 func CustomizeLibertyAnnotations(pts *corev1.PodTemplateSpec, la *wlv1.WebSphereLibertyApplication) {
 	libertyAnnotations := map[string]string{
 		"libertyOperator": "WebSphere Liberty",
 	}
-	pts.Annotations = rcoutils.MergeMaps(pts.Annotations, libertyAnnotations)
+	AddPodTemplateSpecAnnotation(pts, libertyAnnotations)
 }
 
 func CustomizeLicenseAnnotations(pts *corev1.PodTemplateSpec, la *wlv1.WebSphereLibertyApplication) {
@@ -591,6 +693,15 @@ func CustomizeEnvSSO(pts *corev1.PodTemplateSpec, instance *wlv1.WebSphereLibert
 	return nil
 }
 
+func LocalObjectReferenceContainsName(list []corev1.LocalObjectReference, name string) bool {
+	for _, v := range list {
+		if v.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
 func Contains(list []string, s string) bool {
 	for _, v := range list {
 		if v == s {
@@ -636,43 +747,39 @@ func isVolumeFound(pts *corev1.PodTemplateSpec, name string) bool {
 	return false
 }
 
+func ConfigurePasswordEncryption(pts *corev1.PodTemplateSpec, la *wlv1.WebSphereLibertyApplication, operatorShortName string) {
+	// Mount a volume /output/resources/liberty-operator/encryptionKey.xml to store the Liberty Password Encryption Key
+	MountSecretAsVolume(pts, operatorShortName+ManagedEncryptionServerXML, CreateVolumeMount(SecureMountPath, EncryptionKeyXMLFileName))
+
+	// Mount a volume /config/configDropins/overrides/encryptionKeyMount.xml to import the Liberty Password Encryption Key
+	MountSecretAsVolume(pts, operatorShortName+ManagedEncryptionMountServerXML, CreateVolumeMount(overridesMountPath, EncryptionKeyMountXMLFileName))
+}
+
 // ConfigureLTPA setups the shared-storage for LTPA keys file generation
-func ConfigureLTPA(pts *corev1.PodTemplateSpec, la *wlv1.WebSphereLibertyApplication, operatorShortName string) {
-	// Mount a volume /config/managedLTPA to store the ltpa.keys file
-	ltpaKeyVolumeMount := GetLTPAKeysVolumeMount(la, ltpaKeysFileName)
-	if !isVolumeMountFound(pts, ltpaKeyVolumeMount.Name) {
-		pts.Spec.Containers[0].VolumeMounts = append(pts.Spec.Containers[0].VolumeMounts, ltpaKeyVolumeMount)
-	}
-	if !isVolumeFound(pts, ltpaKeyVolumeMount.Name) {
-		vol := corev1.Volume{
-			Name: ltpaKeyVolumeMount.Name,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: operatorShortName + "-managed-ltpa",
-					Items: []corev1.KeyToPath{{
-						Key:  ltpaKeysFileName,
-						Path: ltpaKeysFileName,
-					}},
-				},
-			},
-		}
-		pts.Spec.Volumes = append(pts.Spec.Volumes, vol)
-	}
+func ConfigureLTPA(pts *corev1.PodTemplateSpec, la *wlv1.WebSphereLibertyApplication, operatorShortName string, ltpaSecretName string, ltpaSuffixName string) {
+	// Mount a volume /output/resources/liberty-operator/ltpa.keys to store the ltpa.keys file
+	MountSecretAsVolume(pts, ltpaSecretName, CreateVolumeMount(SecureMountPath, LTPAKeysFileName))
 
-	// Mount a volume /config/configDropins/overrides/ltpa.xml to store the Liberty Server XML
-	ltpaXMLVolumeMount := GetLTPAXMLVolumeMount(la, ltpaXMLFileName)
-	if !isVolumeMountFound(pts, ltpaXMLVolumeMount.Name) {
-		pts.Spec.Containers[0].VolumeMounts = append(pts.Spec.Containers[0].VolumeMounts, ltpaXMLVolumeMount)
+	// Mount a volume /output/resources/liberty-operator/managedLTPA.xml to store the Liberty Server XML
+	MountSecretAsVolume(pts, operatorShortName+LTPAServerXMLSuffix+ltpaSuffixName, CreateVolumeMount(SecureMountPath, LTPAKeysXMLFileName))
+
+	// Mount a volume /config/configDropins/overrides/managedLTPAMount.xml to import the managedLTPA.xml file
+	MountSecretAsVolume(pts, operatorShortName+LTPAServerXMLMountSuffix+ltpaSuffixName, CreateVolumeMount(overridesMountPath, LTPAKeysMountXMLFileName))
+}
+
+func MountSecretAsVolume(pts *corev1.PodTemplateSpec, secretName string, volumeMount corev1.VolumeMount) {
+	if !isVolumeMountFound(pts, volumeMount.Name) {
+		pts.Spec.Containers[0].VolumeMounts = append(pts.Spec.Containers[0].VolumeMounts, volumeMount)
 	}
-	if !isVolumeFound(pts, ltpaXMLVolumeMount.Name) {
+	if !isVolumeFound(pts, volumeMount.Name) {
 		vol := corev1.Volume{
-			Name: ltpaXMLVolumeMount.Name,
+			Name: volumeMount.Name,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: operatorShortName + LTPAServerXMLSuffix,
+					SecretName: secretName,
 					Items: []corev1.KeyToPath{{
-						Key:  ltpaXMLFileName,
-						Path: ltpaXMLFileName,
+						Key:  volumeMount.SubPath,
+						Path: volumeMount.SubPath,
 					}},
 				},
 			},
@@ -681,14 +788,47 @@ func ConfigureLTPA(pts *corev1.PodTemplateSpec, la *wlv1.WebSphereLibertyApplica
 	}
 }
 
-func CustomizeLTPAServerXML(xmlSecret *corev1.Secret, la *wlv1.WebSphereLibertyApplication, encryptedPassword string) {
+func CustomizeEncryptionKeyXML(managedEncryptionXMLSecret *corev1.Secret, encryptionKey string) error {
+	if managedEncryptionXMLSecret.StringData == nil {
+		managedEncryptionXMLSecret.StringData = make(map[string]string)
+	}
+	serverXML, err := os.ReadFile("internal/controller/assets/encryption.xml")
+	if err != nil {
+		return err
+	}
+	severXMLString := strings.Replace(string(serverXML), "WLP_PASSWORD_ENCRYPTION_KEY", encryptionKey, 1)
+	managedEncryptionXMLSecret.StringData[EncryptionKeyXMLFileName] = severXMLString
+	return nil
+}
+
+func CustomizeLTPAServerXML(xmlSecret *corev1.Secret, la *wlv1.WebSphereLibertyApplication, encryptedPassword string) error {
 	xmlSecret.StringData = make(map[string]string)
-	keysFileName := strings.Replace(ltpaKeysMountPath, "/config", "${server.config.dir}", 1)
-	xmlSecret.StringData[ltpaXMLFileName] = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<server>\n    <ltpa keysFileName=\"" + keysFileName + "/" + ltpaKeysFileName + "\" keysPassword=\"" + encryptedPassword + "\" />\n</server>"
+	managedLTPADir := strings.Replace(SecureMountPath, "/output", "${server.output.dir}", 1)
+	serverXML, err := os.ReadFile("internal/controller/assets/ltpa.xml")
+	if err != nil {
+		return err
+	}
+	severXMLString := strings.Replace(string(serverXML), "LTPA_KEYS_FILE_NAME", managedLTPADir+"/"+LTPAKeysFileName, 1)
+	severXMLString = strings.Replace(severXMLString, "LTPA_KEYS_PASSWORD", encryptedPassword, 1)
+	xmlSecret.StringData[LTPAKeysXMLFileName] = severXMLString
+	return nil
 }
 
-// Returns true if the WebSphereApplication leader's state has changed, causing existing LTPA Jobs to need a configuration update, otherwise return false
-func IsLTPAJobConfigurationOutdated(job *v1.Job, appLeaderInstance *wlv1.WebSphereLibertyApplication) bool {
+func CustomizeLibertyFileMountXML(mountingPasswordKeySecret *corev1.Secret, mountXMLFileName string, fileLocation string) error {
+	if mountingPasswordKeySecret.StringData == nil {
+		mountingPasswordKeySecret.StringData = make(map[string]string)
+	}
+	serverXML, err := os.ReadFile("internal/controller/assets/mount.xml")
+	if err != nil {
+		return err
+	}
+	severXMLString := strings.Replace(string(serverXML), "MOUNT_LOCATION", fileLocation, 1)
+	mountingPasswordKeySecret.StringData[mountXMLFileName] = severXMLString
+	return nil
+}
+
+// Returns true if the WebSphereLibertyApplication leader's state has changed, causing existing LTPA Jobs to need a configuration update, otherwise return false
+func IsLTPAJobConfigurationOutdated(job *v1.Job, appLeaderInstance *wlv1.WebSphereLibertyApplication, client client.Client) bool {
 	// The Job contains the leader's pull secret
 	if appLeaderInstance.GetPullSecret() != nil && *appLeaderInstance.GetPullSecret() != "" {
 		ltpaJobHasLeaderPullSecret := false
@@ -699,6 +839,18 @@ func IsLTPAJobConfigurationOutdated(job *v1.Job, appLeaderInstance *wlv1.WebSphe
 		}
 		if !ltpaJobHasLeaderPullSecret {
 			return true
+		}
+	}
+	// The Job contains the leader's custom ServiceAccount's pull secrets
+	if leaderSAName := rcoutils.GetServiceAccountName(appLeaderInstance); len(leaderSAName) > 0 {
+		customServiceAccount := &corev1.ServiceAccount{}
+		if err := client.Get(context.TODO(), types.NamespacedName{Name: leaderSAName, Namespace: appLeaderInstance.GetNamespace()}, customServiceAccount); err == nil {
+			for _, customSAObjectReference := range customServiceAccount.ImagePullSecrets {
+				// If one of the custom SA's pull secret's is not found within the Job, return outdated as true
+				if !LocalObjectReferenceContainsName(job.Spec.Template.Spec.ImagePullSecrets, customSAObjectReference.Name) {
+					return true
+				}
+			}
 		}
 	}
 	if len(job.Spec.Template.Spec.Containers) != 1 {
@@ -715,7 +867,8 @@ func IsLTPAJobConfigurationOutdated(job *v1.Job, appLeaderInstance *wlv1.WebSphe
 	return false
 }
 
-func CustomizeLTPAJob(job *v1.Job, la *wlv1.WebSphereLibertyApplication, ltpaSecretName string, serviceAccountName string, ltpaScriptName string, ltpaJobRequestName string) {
+func CustomizeLTPAJob(job *v1.Job, la *wlv1.WebSphereLibertyApplication, ltpaConfig *LTPAConfig, client client.Client) {
+	ltpaVolumeMountName := parseMountName(ltpaConfig.FileName)
 	encodingType := "aes" // the password encoding type for securityUtility (one of "xor", "aes", or "hash")
 	job.Spec.Template.ObjectMeta.Name = "liberty"
 	job.Spec.Template.Spec.Containers = []corev1.Container{
@@ -726,11 +879,11 @@ func CustomizeLTPAJob(job *v1.Job, la *wlv1.WebSphereLibertyApplication, ltpaSec
 			SecurityContext: rcoutils.GetSecurityContext(la),
 			Command:         []string{"/bin/bash", "-c"},
 			// Usage: /bin/create_ltpa_keys.sh <namespace> <ltpa-secret-name> <securityUtility-encoding>
-			Args: []string{ltpaKeysMountPath + "/bin/create_ltpa_keys.sh " + la.GetNamespace() + " " + ltpaSecretName + " " + ltpaKeysFileName + " " + encodingType + " " + ltpaJobRequestName},
+			Args: []string{managedLTPAMountPath + "/bin/" + LTPAKeysCreationScriptFileName + " " + la.GetNamespace() + " " + ltpaConfig.SecretName + " " + ltpaConfig.SecretInstanceName + " " + ltpaConfig.FileName + " " + encodingType + " " + ltpaConfig.EncryptionKeySecretName + " " + strconv.FormatBool(ltpaConfig.EncryptionKeySharingEnabled) + " " + ResourcePathIndexLabel + " " + ltpaConfig.Metadata.PathIndex + " " + ltpaConfig.JobRequestConfigMapName},
 			VolumeMounts: []corev1.VolumeMount{
 				{
-					Name:      ltpaScriptName,
-					MountPath: ltpaKeysMountPath + "/bin",
+					Name:      ltpaVolumeMountName,
+					MountPath: managedLTPAMountPath + "/bin",
 				},
 			},
 		},
@@ -740,16 +893,29 @@ func CustomizeLTPAJob(job *v1.Job, la *wlv1.WebSphereLibertyApplication, ltpaSec
 			Name: *la.GetPullSecret(),
 		})
 	}
-	job.Spec.Template.Spec.ServiceAccountName = serviceAccountName
+	job.Spec.Template.Spec.ServiceAccountName = ltpaConfig.ServiceAccountName
+	// If there is a custom ServiceAccount, include it's pull secrets into the LTPA Job
+	if leaderSAName := rcoutils.GetServiceAccountName(la); len(leaderSAName) > 0 {
+		customServiceAccount := &corev1.ServiceAccount{}
+		if err := client.Get(context.TODO(), types.NamespacedName{Name: leaderSAName, Namespace: la.GetNamespace()}, customServiceAccount); err == nil {
+			// For each of the custom SA's pull secret's, if it is not found within the Job, append it to the Job
+			for _, customSAObjectReference := range customServiceAccount.ImagePullSecrets {
+				if !LocalObjectReferenceContainsName(job.Spec.Template.Spec.ImagePullSecrets, customSAObjectReference.Name) {
+					job.Spec.Template.Spec.ImagePullSecrets = append(job.Spec.Template.Spec.ImagePullSecrets, corev1.LocalObjectReference{
+						Name: customSAObjectReference.Name,
+					})
+				}
+			}
+		}
+	}
 	job.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyOnFailure
-	var number int32
-	number = 0777
+	number := int32(0777)
 	job.Spec.Template.Spec.Volumes = append(job.Spec.Template.Spec.Volumes, corev1.Volume{
-		Name: ltpaScriptName,
+		Name: ltpaVolumeMountName,
 		VolumeSource: corev1.VolumeSource{
 			ConfigMap: &corev1.ConfigMapVolumeSource{
 				LocalObjectReference: corev1.LocalObjectReference{
-					Name: ltpaScriptName,
+					Name: ltpaConfig.ConfigMapName,
 				},
 				DefaultMode: &number,
 			},
@@ -757,18 +923,58 @@ func CustomizeLTPAJob(job *v1.Job, la *wlv1.WebSphereLibertyApplication, ltpaSec
 	})
 }
 
-func GetLTPAKeysVolumeMount(la *wlv1.WebSphereLibertyApplication, fileName string) corev1.VolumeMount {
-	return corev1.VolumeMount{
-		Name:      "ltpa-keys",
-		MountPath: ltpaKeysMountPath + "/" + fileName,
-		SubPath:   fileName,
+// Converts a file name into a lowercase word separated string
+// Example: managedLTPASecret.xml -> managed-ltpa-secret-xml
+func parseMountName(fileName string) string {
+	i := 0
+	n := len(fileName)
+	mountName := ""
+	previousUpper := false
+	for i < n {
+		ch := string(fileName[i])
+		if ch == "." {
+			mountName += "-"
+		} else if ch == strings.ToUpper(ch) {
+			if !previousUpper && i > 0 {
+				mountName += "-"
+			}
+			mountName += strings.ToLower(ch)
+			previousUpper = true
+		} else {
+			mountName += ch
+			previousUpper = false
+		}
+		i += 1
 	}
+	return mountName
 }
 
-func GetLTPAXMLVolumeMount(la *wlv1.WebSphereLibertyApplication, fileName string) corev1.VolumeMount {
+func kebabToCamelCase(inputString string) string {
+	i := 0
+	n := len(inputString)
+	outputString := ""
+	for i < n && string(inputString[i]) == "-" {
+		i += 1
+	}
+	for i < n {
+		ch := string(inputString[i])
+		if ch == "-" {
+			if i < n-1 {
+				outputString += strings.ToUpper(string(inputString[i+1]))
+			}
+			i += 2
+		} else {
+			outputString += ch
+			i += 1
+		}
+	}
+	return outputString
+}
+
+func CreateVolumeMount(mountPath string, fileName string) corev1.VolumeMount {
 	return corev1.VolumeMount{
-		Name:      "ltpa-xml",
-		MountPath: ltpaServerXMLOverridesMountPath + fileName,
+		Name:      parseMountName(fileName),
+		MountPath: mountPath + "/" + fileName,
 		SubPath:   fileName,
 	}
 }
@@ -783,4 +989,150 @@ func GetRequiredLabels(name string, instance string) map[string]string {
 	}
 	requiredLabels["app.kubernetes.io/managed-by"] = "websphere-liberty-operator"
 	return requiredLabels
+}
+
+func IsOperandVersionString(version string) bool {
+	if !strings.Contains(version, "_") {
+		return false
+	}
+	if version[0] != 'v' {
+		return false
+	}
+	versionArray := strings.Split(version, "_")
+	n := len(versionArray)
+	return n == 3
+}
+
+func GetFirstNumberFromString(target string) string {
+	k := 0
+	for k < len(target) {
+		if _, err := strconv.Atoi(string(target[k])); err != nil {
+			break
+		}
+		k += 1
+	}
+	return target[:k]
+}
+
+// Converts semantic version string "a.b.c" to format "va_b_c"
+func GetOperandVersionString() (string, error) {
+	if !strings.Contains(OperandVersion, ".") {
+		return "", fmt.Errorf("expected OperandVersion to be in semantic version format")
+	}
+	versionArray := strings.Split(OperandVersion, ".")
+	n := len(versionArray)
+	if n != 3 {
+		return "", fmt.Errorf("expected OperandVersion to be in semantic version format with 3 arguments")
+	}
+	finalVersion := "v"
+	for i, version := range versionArray {
+		if i < n-1 {
+			if version != GetFirstNumberFromString(version) {
+				return "", fmt.Errorf("expected OperandVersion not to contain build manifest data in the first two arguments")
+			}
+			finalVersion += version
+			finalVersion += "_"
+		} else {
+			// trim the end for possible build metadata
+			finalVersion += GetFirstNumberFromString(version)
+		}
+	}
+	return finalVersion, nil
+}
+
+func GetCommaSeparatedArray(stringList string) []string {
+	if strings.Contains(stringList, ",") {
+		return strings.Split(stringList, ",")
+	}
+	return []string{stringList}
+}
+
+var letterNums = []rune("abcdefghijklmnopqrstuvwxyz1234567890")
+
+func GetRandomLowerAlphanumericSuffix(length int) string {
+	b := make([]rune, length)
+	for i := range b {
+		b[i] = letterNums[rand.IntN(len(letterNums))]
+	}
+	return "-" + string(b)
+}
+
+func IsLowerAlphanumericSuffix(suffix string) bool {
+	for _, ch := range suffix {
+		numCheck := int(ch - '0')
+		lowerAlphaCheck := int(ch - 'a')
+		if !((numCheck >= 0 && numCheck <= 9) || (lowerAlphaCheck >= 0 && lowerAlphaCheck <= 25)) {
+			return false
+		}
+	}
+	return true
+}
+
+func GetCommaSeparatedString(stringList string, index int) (string, error) {
+	if stringList == "" {
+		return "", fmt.Errorf("there is no element")
+	}
+	if strings.Contains(stringList, ",") {
+		for i, val := range strings.Split(stringList, ",") {
+			if index == i {
+				return val, nil
+			}
+		}
+	} else {
+		if index == 0 {
+			return stringList, nil
+		}
+		return "", fmt.Errorf("cannot index string list with only one element")
+	}
+	return "", fmt.Errorf("element not found")
+}
+
+// returns the index of the contained value in stringList or else -1
+func CommaSeparatedStringContains(stringList string, value string) int {
+	if strings.Contains(stringList, ",") {
+		for i, label := range strings.Split(stringList, ",") {
+			if value == label {
+				return i
+			}
+		}
+	} else if stringList == value {
+		return 0
+	}
+	return -1
+}
+
+func IsValidOperandVersion(version string) bool {
+	if len(version) == 0 {
+		return false
+	}
+	if version[0] != 'v' {
+		return false
+	}
+	if !strings.Contains(version[1:], "_") {
+		return false
+	}
+	versions := strings.Split(version[1:], "_")
+	if len(versions) != 3 {
+		return false
+	}
+	for _, version := range versions {
+		if len(GetFirstNumberFromString(version)) == 0 {
+			return false
+		}
+	}
+
+	return true
+}
+
+func CompareOperandVersion(a string, b string) int {
+	arrA := strings.Split(a[1:], "_")
+	arrB := strings.Split(b[1:], "_")
+	for i := range arrA {
+		intA, _ := strconv.ParseInt(GetFirstNumberFromString(arrA[i]), 10, 64)
+		intB, _ := strconv.ParseInt(GetFirstNumberFromString(arrB[i]), 10, 64)
+		if intA != intB {
+			return int(intA - intB)
+		}
+	}
+	return 0
 }


### PR DESCRIPTION
For issue https://github.com/OpenLiberty/open-liberty-operator/issues/569

- Support multiple LTPA keys across operator versions using a decision tree where each leaf represents a resource (LTPA key) combination. 
    - Use keys across versions by following instructions in and updating the `internal/controller/assets/ltpa-decision-tree.yaml` file and implementing `reconcileLTPAMetadata()` in `ltpa_keys_sharing.go`.
- Adds the `tree` folder and package tests which provides the decision tree impl. that can be extended to be used for a variety Kubernetes resources
- Adds the `controllers/password_encryption_key_sharing.go` which treats a password encryption key Secret (provided by user) as a namespace-shared resource, mounted into each Liberty application that sets `.spec.managePasswordEncryption` to `true`, within the same namespace.
- Securely mount and load LTPA key from `/output/security/liberty-operator` by using `<include location="...">` in `/config/configDropins/overrides`
- Securely mount and load password encryption key from `/output/security/liberty-operator` by using `<include location="...">` in `/config/configDropins/overrides`