### PR TITLE
Add logging levels to reduce default log output

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	"github.com/application-stacks/runtime-component-operator/common"
 	"github.com/application-stacks/runtime-component-operator/utils"
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	imagev1 "github.com/openshift/api/image/v1"
@@ -78,7 +79,14 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	utils.CreateConfigMap(controller.OperatorName)
+
+	opts := zap.Options{
+		Level:           common.LevelFunc,
+		StacktraceLevel: common.StackLevelFunc,
+		Development:     true,
+	}
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	// see https://github.com/operator-framework/operator-sdk/issues/1813
 	leaseDuration := 30 * time.Second
@@ -151,8 +159,6 @@ func main() {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}
-
-	utils.CreateConfigMap(controller.OperatorName)
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23
 
 require (
 	github.com/OpenLiberty/open-liberty-operator v0.8.1-0.20241118200244-c535feadcf42
-	github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20241118182902-2340c1cdeff2
+	github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20241120210837-2650f9d4b763
 	github.com/cert-manager/cert-manager v1.13.6
 	github.com/go-logr/logr v1.3.0
 	github.com/openshift/api v0.0.0-20230928134114-673ed0cfc7f1

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/OpenLiberty/open-liberty-operator v0.8.1-0.20241118200244-c535feadcf4
 github.com/OpenLiberty/open-liberty-operator v0.8.1-0.20241118200244-c535feadcf42/go.mod h1:+s432/Ut8VSUHpvnird0mBa5o0O4MdSxVXfyePHOaNA=
 github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20241118182902-2340c1cdeff2 h1:dv5rxcqVkCFbWtH4N4U8AA7M284DXhXgC3eEls2KETk=
 github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20241118182902-2340c1cdeff2/go.mod h1:Q//a3yubxjR3+COorasymYRuuiDPs0Usgl9YuADkD6U=
+github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20241120210837-2650f9d4b763 h1:qs+ovAwqaRrx2MTvtM8Elc3anZNUNBDah3KwDeNabb8=
+github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20241120210837-2650f9d4b763/go.mod h1:Q//a3yubxjR3+COorasymYRuuiDPs0Usgl9YuADkD6U=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/internal/controller/webspherelibertyapplication_controller.go
+++ b/internal/controller/webspherelibertyapplication_controller.go
@@ -87,6 +87,7 @@ const applicationFinalizer = "finalizer.webspherelibertyapps.liberty.websphere.i
 // move the current state of the cluster closer to the desired state.
 func (r *ReconcileWebSphereLiberty) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	reqLogger := r.Log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	reqDebugLogger := reqLogger.V(common.LogLevelDebug)
 	reqLogger.Info("Reconcile WebSphereLibertyApplication - starting")
 	ns, err := oputils.GetOperatorNamespace()
 	if err != nil {
@@ -330,7 +331,7 @@ func (r *ReconcileWebSphereLiberty) Reconcile(ctx context.Context, request ctrl.
 	// Check if SemeruCloudCompiler is enabled before reconciling the Semeru Compiler deployment and service.
 	// Otherwise, delete the Semeru Compiler deployment and service.
 	message := "Start Semeru Compiler reconcile"
-	reqLogger.Info(message)
+	reqDebugLogger.Info(message)
 	err, message, areCompletedSemeruInstancesMarkedToBeDeleted := r.reconcileSemeruCompiler(instance)
 	if err != nil {
 		reqLogger.Error(err, message)


### PR DESCRIPTION
Picks up latest RCO for log level framework, and moves 'semeru start' log messages to debug level
Part of https://github.com/OpenLiberty/open-liberty-operator/issues/638