### PR TITLE
Update dump file name to be compatible with all platforms including Windows

### DIFF
--- a/internal/controller/webspherelibertydump_controller.go
+++ b/internal/controller/webspherelibertydump_controller.go
@@ -109,7 +109,7 @@ func (r *ReconcileWebSphereLibertyDump) Reconcile(ctx context.Context, request c
 
 	currentTime := time.Now()
 	dumpFolder := "/serviceability/" + pod.Namespace + "/" + pod.Name
-	dumpFileName := dumpFolder + "/" + "dump_" + currentTime.UTC().Format("2006.01.02_15.04.05_utc") + ".zip"
+	dumpFileName := dumpFolder + "/" + "dump_" + currentTime.UTC().Format("2006.01.02_15.04.05") + "_utc.zip"
 	dumpCmd := "mkdir -p " + dumpFolder + " &&  server dump --archive=" + dumpFileName
 	if len(instance.Spec.Include) > 0 {
 		dumpCmd += " --include="

--- a/internal/controller/webspherelibertydump_controller.go
+++ b/internal/controller/webspherelibertydump_controller.go
@@ -107,9 +107,9 @@ func (r *ReconcileWebSphereLibertyDump) Reconcile(ctx context.Context, request c
 		return reconcile.Result{}, nil
 	}
 
-	time := time.Now()
+	currentTime := time.Now()
 	dumpFolder := "/serviceability/" + pod.Namespace + "/" + pod.Name
-	dumpFileName := dumpFolder + "/" + time.Format("2006-01-02_15:04:05") + ".zip"
+	dumpFileName := dumpFolder + "/" + "dump_" + currentTime.UTC().Format("2006.01.02_15.04.05_utc") + ".zip"
 	dumpCmd := "mkdir -p " + dumpFolder + " &&  server dump --archive=" + dumpFileName
 	if len(instance.Spec.Include) > 0 {
 		dumpCmd += " --include="


### PR DESCRIPTION
Update the dump file name to be compatible with all platforms. Old filename format (i.e. `2025-04-09_15:29:07.zip`) is not compatible with Windows.

PR for https://github.com/WASdev/websphere-liberty-operator/issues/745

Tested the changes locally:

WebSphereLibertyDump CR status:
```
status:
  conditions:
    - lastUpdateTime: '2025-04-28T17:27:05Z'
      status: 'True'
      type: Started
    - lastUpdateTime: '2025-04-28T17:27:08Z'
      status: 'True'
      type: Completed
  dumpFile: /serviceability/liberty/websphereliberty-app-sample-d4766d9cf-7lgm8/dump_2025.04.28_17.27.05_utc.zip
  observedGeneration: 1
  versions:
    reconciled: 1.4.2
```

Created file within the serviceability directory:
```

sh-4.4$ ls -R serviceability/
serviceability/:
liberty

serviceability/liberty:
websphereliberty-app-sample-d4766d9cf-7lgm8 

serviceability/liberty/websphereliberty-app-sample-d4766d9cf-7lgm8:
dump_2025.04.28_17.17.31_utc.zip  dump_2025.04.28_17.27.05_utc.zip
```

