### PR TITLE
Ensure Ready status first 

### DIFF
--- a/api/v1/webspherelibertyapplication_types.go
+++ b/api/v1/webspherelibertyapplication_types.go
@@ -17,6 +17,7 @@
 package v1
 
 import (
+	"sort"
 	"time"
 
 	"github.com/application-stacks/runtime-component-operator/common"
@@ -1630,6 +1631,17 @@ func (s *WebSphereLibertyApplicationStatus) SetCondition(c common.StatusConditio
 	if !found {
 		s.Conditions = append(s.Conditions, *condition)
 	}
+
+	// Re-sort conditions to prioritize 'Ready' condition
+	sort.Slice(s.Conditions, func(i, j int) bool {
+		if s.Conditions[i].GetType() == common.StatusConditionTypeReady {
+			return true
+		}
+		if s.Conditions[j].GetType() == common.StatusConditionTypeReady {
+			return false
+		}
+		return s.Conditions[i].GetType() < s.Conditions[j].GetType()
+	})
 }
 
 func (s *WebSphereLibertyApplicationStatus) UnsetCondition(c common.StatusCondition) {


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Guarantees Ready always exists and is first in `.status.conditions` by initialising during reconcile and normalising order

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
https://github.com/OpenLiberty/open-liberty-operator/issues/724