### PR TITLE
Additional updates for 1.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -ldflags="-s -w" -a -o mana
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-21-jre-ubi-minimal
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-21-jre-ubi9-minimal
 
 ARG USER_ID=65532
 ARG GROUP_ID=65532

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -148,7 +148,7 @@ func main() {
 		Log:               ctrl.Log.WithName("controller").WithName("WebSphereLibertyPerformanceData"),
 		PodInjectorClient: socket.GetPodInjectorClient(ctrl.Log.WithName("controller").WithName("PodInjectorClient").V(common.LogLevelDebug)),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "OpenLibertyPerformanceData")
+		setupLog.Error(err, "unable to create controller", "controller", "WebSphereLibertyPerformanceData")
 		os.Exit(1)
 	}
 	if err = (&controller.ReconcileWebSphereLibertyTrace{

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -76,7 +76,7 @@ spec:
           - name: RELATED_IMAGE_LIBERTY_SAMPLE_APP
             value: icr.io/appcafe/open-liberty/samples/getting-started@sha256:29220c85330a584ab1a22de6771d8b10a36796dd666f2b5b8c4dd92a8f8e76e0
           - name: RELATED_IMAGE_WEBSPHERE_LIBERTY_OPERATOR
-            value: icr.io/cpopen/websphere-liberty-operator:daily
+            value: OPERATOR_IMAGE
         securityContext:
           allowPrivilegeEscalation: false
           privileged: false

--- a/config/manifests/patches/csvAnnotations.yaml
+++ b/config/manifests/patches/csvAnnotations.yaml
@@ -4,5 +4,5 @@ metadata:
   name: ibm-websphere-liberty.v0.0.0
   namespace: placeholder
   annotations:
-    containerImage: icr.io/cpopen/websphere-liberty-operator:daily
-    createdAt: 2025-08-19T12:14:58Z
+    containerImage: IMAGE
+    createdAt: CREATEDAT


### PR DESCRIPTION
- Update the Operator base image (Semeru) to UBI 9 minimal
- Reverse changes to placeholders for patches
- Update reference to OpenLibertyPerformanceData in log