### PR TITLE
Pull upstream perf data fixes

### DIFF
--- a/api/v1/webspherelibertyperformancedata_types.go
+++ b/api/v1/webspherelibertyperformancedata_types.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"time"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -66,10 +68,6 @@ type WebSphereLibertyPerformanceDataList struct {
 	Items           []WebSphereLibertyPerformanceData `json:"items"`
 }
 
-func init() {
-	SchemeBuilder.Register(&WebSphereLibertyPerformanceData{}, &WebSphereLibertyPerformanceDataList{})
-}
-
 func getIntValueOrDefault(value *int, defaultValue int) int {
 	if value == nil {
 		return defaultValue
@@ -87,4 +85,63 @@ func (cr *WebSphereLibertyPerformanceData) GetTimespan() int {
 func (cr *WebSphereLibertyPerformanceData) GetInterval() int {
 	defaultInterval := 30
 	return getIntValueOrDefault(cr.Spec.Interval, defaultInterval)
+}
+
+// GetStatus return condition's status
+func (cr *WebSphereLibertyPerformanceData) GetStatus() *WebSphereLibertyPerformanceDataStatus {
+	return &cr.Status
+}
+
+// NewCondition returns new condition
+func (s *WebSphereLibertyPerformanceDataStatus) NewCondition() OperationStatusCondition {
+	return OperationStatusCondition{}
+}
+
+// GetConditions returns slice of conditions
+func (s *WebSphereLibertyPerformanceDataStatus) GetConditions() []OperationStatusCondition {
+	var conditions = []OperationStatusCondition{}
+	for i := range s.Conditions {
+		conditions[i] = s.Conditions[i]
+	}
+	return conditions
+}
+
+// GetCondition ...
+func (s *WebSphereLibertyPerformanceDataStatus) GetCondition(t OperationStatusConditionType) OperationStatusCondition {
+
+	for i := range s.Conditions {
+		if s.Conditions[i].GetType() == t {
+			return s.Conditions[i]
+		}
+	}
+	return OperationStatusCondition{LastUpdateTime: metav1.Time{}} //revisit
+}
+
+// SetCondition ...
+func (s *WebSphereLibertyPerformanceDataStatus) SetCondition(c OperationStatusCondition) {
+	condition := &OperationStatusCondition{}
+	found := false
+	for i := range s.Conditions {
+		if s.Conditions[i].GetType() == c.GetType() {
+			condition = &s.Conditions[i]
+			found = true
+			break
+		}
+	}
+
+	if condition.GetStatus() != c.GetStatus() || condition.GetMessage() != c.GetMessage() || condition.GetReason() != c.GetReason() {
+		condition.SetLastTransitionTime(&metav1.Time{Time: time.Now()})
+	}
+
+	condition.SetReason(c.GetReason())
+	condition.SetMessage(c.GetMessage())
+	condition.SetStatus(c.GetStatus())
+	condition.SetType(c.GetType())
+	if !found {
+		s.Conditions = append(s.Conditions, *condition)
+	}
+}
+
+func init() {
+	SchemeBuilder.Register(&WebSphereLibertyPerformanceData{}, &WebSphereLibertyPerformanceDataList{})
 }

--- a/api/v1/webspherelibertytrace_types.go
+++ b/api/v1/webspherelibertytrace_types.go
@@ -61,6 +61,9 @@ type WebSphereLibertyTraceStatus struct {
 	Conditions       []OperationStatusCondition `json:"conditions,omitempty"`
 	OperatedResource OperatedResource           `json:"operatedResource,omitempty"`
 	Versions         TraceStatusVersions        `json:"versions,omitempty"`
+	// Location of the trace log directory
+	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="Log Directory",xDescriptors="urn:alm:descriptor:com.tectonic.ui:text"
+	LogDirectory string `json:"logDirectory,omitempty"`
 	// The generation identifier of this WebSphereLibertyTrace instance completely reconciled by the Operator.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }

--- a/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
@@ -67,7 +67,7 @@ metadata:
     capabilities: Auto Pilot
     categories: Application Runtime
     containerImage: icr.io/cpopen/websphere-liberty-operator:daily
-    createdAt: "2025-09-05T20:20:25Z"
+    createdAt: "2025-09-05T21:00:37Z"
     description: Deploy and manage containerized Liberty applications
     features.operators.openshift.io/disconnected: "true"
     olm.skipRange: '>=1.0.0 <1.5.0'

--- a/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
@@ -67,7 +67,7 @@ metadata:
     capabilities: Auto Pilot
     categories: Application Runtime
     containerImage: icr.io/cpopen/websphere-liberty-operator:daily
-    createdAt: "2025-09-05T21:00:37Z"
+    createdAt: "2025-09-05T21:54:24Z"
     description: Deploy and manage containerized Liberty applications
     features.operators.openshift.io/disconnected: "true"
     olm.skipRange: '>=1.0.0 <1.5.0'
@@ -800,6 +800,12 @@ spec:
         path: license.accept
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:checkbox
+      statusDescriptors:
+      - description: Location of the trace log directory
+        displayName: Log Directory
+        path: logDirectory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       version: v1
   displayName: IBM WebSphere Liberty
   description: |

--- a/bundle/manifests/liberty.websphere.ibm.com_webspherelibertytraces.yaml
+++ b/bundle/manifests/liberty.websphere.ibm.com_webspherelibertytraces.yaml
@@ -126,6 +126,9 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
+              logDirectory:
+                description: Location of the trace log directory
+                type: string
               observedGeneration:
                 description: The generation identifier of this WebSphereLibertyTrace
                   instance completely reconciled by the Operator.

--- a/config/crd/bases/liberty.websphere.ibm.com_webspherelibertytraces.yaml
+++ b/config/crd/bases/liberty.websphere.ibm.com_webspherelibertytraces.yaml
@@ -122,6 +122,9 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
+              logDirectory:
+                description: Location of the trace log directory
+                type: string
               observedGeneration:
                 description: The generation identifier of this WebSphereLibertyTrace
                   instance completely reconciled by the Operator.

--- a/config/manifests/bases/ibm-websphere-liberty.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-websphere-liberty.clusterserviceversion.yaml
@@ -660,6 +660,12 @@ spec:
         path: license.accept
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:checkbox
+      statusDescriptors:
+      - description: Location of the trace log directory
+        displayName: Log Directory
+        path: logDirectory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       version: v1
   displayName: IBM WebSphere Liberty
   icon:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/WASdev/websphere-liberty-operator
 go 1.25
 
 require (
-	github.com/OpenLiberty/open-liberty-operator v0.8.1-0.20250825204924-e4323ba51951
+	github.com/OpenLiberty/open-liberty-operator v0.8.1-0.20250905192627-9744db597e0c
 	github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20250819191004-e7c72e158a1c
 	github.com/cert-manager/cert-manager v1.16.5
 	github.com/go-logr/logr v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/OpenLiberty/open-liberty-operator v0.8.1-0.20250825204924-e4323ba51951 h1:Cc6WOtjmSBP8/rX2nD6YnRrU6OXN+jiOc4fAHaA7sA4=
 github.com/OpenLiberty/open-liberty-operator v0.8.1-0.20250825204924-e4323ba51951/go.mod h1:WQFReKJqTX+dE6TkzFF+CqjR7EeS0UMCg7a8/UVlrn8=
+github.com/OpenLiberty/open-liberty-operator v0.8.1-0.20250905192627-9744db597e0c h1:Xv3cdaC6J/leLUksElFFUo3c88qJyp6LrQSYce07H/g=
+github.com/OpenLiberty/open-liberty-operator v0.8.1-0.20250905192627-9744db597e0c/go.mod h1:WQFReKJqTX+dE6TkzFF+CqjR7EeS0UMCg7a8/UVlrn8=
 github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20250819191004-e7c72e158a1c h1:4lPD9kNTeyy0Q8UnSAxC/hXLnaQyF6AtVYklhsA9rzU=
 github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20250819191004-e7c72e158a1c/go.mod h1:Hs5AbE9J+rLM34IAc75X7dtxnrzFg2AvG1XYLcX/ApU=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,6 @@ github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg6
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
-github.com/OpenLiberty/open-liberty-operator v0.8.1-0.20250825204924-e4323ba51951 h1:Cc6WOtjmSBP8/rX2nD6YnRrU6OXN+jiOc4fAHaA7sA4=
-github.com/OpenLiberty/open-liberty-operator v0.8.1-0.20250825204924-e4323ba51951/go.mod h1:WQFReKJqTX+dE6TkzFF+CqjR7EeS0UMCg7a8/UVlrn8=
 github.com/OpenLiberty/open-liberty-operator v0.8.1-0.20250905192627-9744db597e0c h1:Xv3cdaC6J/leLUksElFFUo3c88qJyp6LrQSYce07H/g=
 github.com/OpenLiberty/open-liberty-operator v0.8.1-0.20250905192627-9744db597e0c/go.mod h1:WQFReKJqTX+dE6TkzFF+CqjR7EeS0UMCg7a8/UVlrn8=
 github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20250819191004-e7c72e158a1c h1:4lPD9kNTeyy0Q8UnSAxC/hXLnaQyF6AtVYklhsA9rzU=

--- a/internal/controller/assets/helper/linperf.sh
+++ b/internal/controller/assets/helper/linperf.sh
@@ -175,6 +175,20 @@ elif [ $ROOT_ACCESS_REQUIRED -eq 0 ]; then
   echo $(date '+%Y-%m-%d %H:%M:%S') "\tWarning: Root access is disabled. Data may be incomplete."
 fi
 
+############################
+# Create serviceability link
+############################
+if ! test -L /liberty/logs; then
+  if [[ ! -z "$SERVICEABILITY_NAMESPACE" ]] && [[ ! -z $HOSTNAME ]]; then
+    SERVICEABILITY_FOLDER="/serviceability/$SERVICEABILITY_NAMESPACE/$HOSTNAME/logs"
+    mkdir -p $SERVICEABILITY_FOLDER
+    rm -rf /liberty/logs
+    ln -s $SERVICEABILITY_FOLDER /liberty/logs
+  else
+    ln -s /serviceability /liberty/logs
+  fi
+fi
+
 ################################
 # Assign OUTPUT_DIR and DIR_NAME 
 ################################

--- a/internal/controller/assets/helper/linperf.sh
+++ b/internal/controller/assets/helper/linperf.sh
@@ -178,11 +178,10 @@ fi
 ############################
 # Create serviceability link
 ############################
-if ! test -L /liberty/logs; then
+if ! test -f /liberty/logs; then
   if [[ ! -z "$SERVICEABILITY_NAMESPACE" ]] && [[ ! -z $HOSTNAME ]]; then
     SERVICEABILITY_FOLDER="/serviceability/$SERVICEABILITY_NAMESPACE/$HOSTNAME/logs"
     mkdir -p $SERVICEABILITY_FOLDER
-    rm -rf /liberty/logs
     ln -s $SERVICEABILITY_FOLDER /liberty/logs
   else
     ln -s /serviceability /liberty/logs

--- a/internal/controller/assets/helper/linperf.sh
+++ b/internal/controller/assets/helper/linperf.sh
@@ -178,7 +178,7 @@ fi
 ############################
 # Create serviceability link
 ############################
-if ! test -f /liberty/logs; then
+if ! test -e /liberty/logs; then
   if [[ ! -z "$SERVICEABILITY_NAMESPACE" ]] && [[ ! -z $HOSTNAME ]]; then
     SERVICEABILITY_FOLDER="/serviceability/$SERVICEABILITY_NAMESPACE/$HOSTNAME/logs"
     mkdir -p $SERVICEABILITY_FOLDER

--- a/internal/controller/webspherelibertydump_controller.go
+++ b/internal/controller/webspherelibertydump_controller.go
@@ -108,7 +108,7 @@ func (r *ReconcileWebSphereLibertyDump) Reconcile(ctx context.Context, request c
 	}
 
 	currentTime := time.Now()
-	dumpFolder := "/serviceability/" + pod.Namespace + "/" + pod.Name
+	dumpFolder := "/serviceability/" + pod.Namespace + "/" + pod.Name + "/serverDumps"
 	dumpFileName := dumpFolder + "/" + "dump_" + currentTime.UTC().Format("2006.01.02_15.04.05") + "_utc.zip"
 	dumpCmd := "mkdir -p " + dumpFolder + " &&  server dump --archive=" + dumpFileName
 	if len(instance.Spec.Include) > 0 {

--- a/internal/deploy/kubectl/websphereliberty-app-crd.yaml
+++ b/internal/deploy/kubectl/websphereliberty-app-crd.yaml
@@ -10087,6 +10087,9 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
+              logDirectory:
+                description: Location of the trace log directory
+                type: string
               observedGeneration:
                 description: The generation identifier of this WebSphereLibertyTrace
                   instance completely reconciled by the Operator.

--- a/internal/deploy/kustomize/daily/base/websphere-liberty-crd.yaml
+++ b/internal/deploy/kustomize/daily/base/websphere-liberty-crd.yaml
@@ -10087,6 +10087,9 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
+              logDirectory:
+                description: Location of the trace log directory
+                type: string
               observedGeneration:
                 description: The generation identifier of this WebSphereLibertyTrace
                   instance completely reconciled by the Operator.


### PR DESCRIPTION
- Pulls upstream perf data fixes from `open-liberty-operator@main`
- Add `.status.logDirectory` to trace CR and add `serverDumps` subfolder to dumps