### PR TITLE
Verify that performance data commands exist

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -275,15 +275,20 @@ func GetLinperfCmd(encodedAttrs, podName, podNamespace string) string {
 	linperfCmdArgs = append(linperfCmdArgs, "--ignore-root")
 	linperfCmd := strings.Join(linperfCmdArgs, FlagDelimiterSpace)
 
-	requiredPackages := []string{"procps-ng", "net-tools", "ncurses", "hostname"}
+	// requiredPackages := []string{"procps-ng", "net-tools", "ncurses", "hostname"}
+	// cmdArgs := []string{}
+	// for _, pkg := range requiredPackages {
+	// 	cmdArgs = append(cmdArgs, fmt.Sprintf("$pkgcmd list installed %s", pkg))
+	// }
+	requiredCLIs := []string{"netstat", "ps", "dmesg", "tput", "ifconfig", "vmstat", "top", "uptime"}
 	cmdArgs := []string{}
-	for _, pkg := range requiredPackages {
-		cmdArgs = append(cmdArgs, fmt.Sprintf("$pkgcmd list installed %s", pkg))
+	for _, cli := range requiredCLIs {
+		cmdArgs = append(cmdArgs, fmt.Sprintf("command -v %s >/dev/null 2>&1", cli))
 	}
-	checkPackagesCmd := strings.Join(cmdArgs, " && ") // add spaces for readability
+	checkCLICmd := strings.Join(cmdArgs, " && ") // add spaces for readability
 
 	// linperfCmdWithPids := fmt.Sprintf("mkdir -p %s && PIDS=$(ls -l /proc/[0-9]*/exe | grep \"/java$\" | xargs -L 1 | cut -d ' ' -f9 | cut -d '/' -f 3 ) && PIDS_OUT=$(echo $PIDS | tr '\n' ' ') && ls -l /proc/[0-9]*/exe > /serviceability/%s/%s/test.out && %s \"1\"", outputDir, podNamespace, podName, linperfCmd)
-	linperfCmdWithPids := fmt.Sprintf("if ! (command -v yum && pkgcmd=yum || pkgcmd=microdnf && %s); then exit 130; elif [ $(df | grep %s -c) -eq 0 ]; then exit 129; else mkdir -p %s && %s \"1\"; fi", checkPackagesCmd, serviceabilityRootDir, outputDir, linperfCmd)
+	linperfCmdWithPids := fmt.Sprintf("if ! (%s); then exit 130; elif [ $(df | grep %s -c) -eq 0 ]; then exit 129; else mkdir -p %s && %s \"1\"; fi", checkCLICmd, serviceabilityRootDir, outputDir, linperfCmd)
 	// fmt.Println("Linperf cmd: " + linperfCmdWithPids) // un-commment this line for debugging
 	return linperfCmdWithPids
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -275,19 +275,13 @@ func GetLinperfCmd(encodedAttrs, podName, podNamespace string) string {
 	linperfCmdArgs = append(linperfCmdArgs, "--ignore-root")
 	linperfCmd := strings.Join(linperfCmdArgs, FlagDelimiterSpace)
 
-	// requiredPackages := []string{"procps-ng", "net-tools", "ncurses", "hostname"}
-	// cmdArgs := []string{}
-	// for _, pkg := range requiredPackages {
-	// 	cmdArgs = append(cmdArgs, fmt.Sprintf("$pkgcmd list installed %s", pkg))
-	// }
-	requiredCLIs := []string{"netstat", "ps", "dmesg", "tput", "ifconfig", "vmstat", "top", "uptime"}
+	requiredCLIs := []string{"netstat", "ps", "dmesg", "tput", "ifconfig", "vmstat", "top", "uptime", "hostname"}
 	cmdArgs := []string{}
 	for _, cli := range requiredCLIs {
 		cmdArgs = append(cmdArgs, fmt.Sprintf("command -v %s >/dev/null 2>&1", cli))
 	}
 	checkCLICmd := strings.Join(cmdArgs, " && ") // add spaces for readability
 
-	// linperfCmdWithPids := fmt.Sprintf("mkdir -p %s && PIDS=$(ls -l /proc/[0-9]*/exe | grep \"/java$\" | xargs -L 1 | cut -d ' ' -f9 | cut -d '/' -f 3 ) && PIDS_OUT=$(echo $PIDS | tr '\n' ' ') && ls -l /proc/[0-9]*/exe > /serviceability/%s/%s/test.out && %s \"1\"", outputDir, podNamespace, podName, linperfCmd)
 	linperfCmdWithPids := fmt.Sprintf("if ! (%s); then exit 130; elif [ $(df | grep %s -c) -eq 0 ]; then exit 129; else mkdir -p %s && %s \"1\"; fi", checkCLICmd, serviceabilityRootDir, outputDir, linperfCmd)
 	// fmt.Println("Linperf cmd: " + linperfCmdWithPids) // un-commment this line for debugging
 	return linperfCmdWithPids


### PR DESCRIPTION
- Support checking CLI commands directly required by linperf.sh for container images that don't have a package manager (yum/microdnf).