### PR TITLE
Set a size limit (20Mi) on the temporary emptyDirs

### DIFF
--- a/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-websphere-liberty.clusterserviceversion.yaml
@@ -67,7 +67,7 @@ metadata:
     capabilities: Auto Pilot
     categories: Application Runtime
     containerImage: icr.io/cpopen/websphere-liberty-operator:daily
-    createdAt: "2025-11-12T02:36:20Z"
+    createdAt: "2025-11-12T19:54:07Z"
     description: Deploy and manage containerized Liberty applications
     features.operators.openshift.io/disconnected: "true"
     olm.skipRange: '>=1.0.0 <1.5.2'
@@ -1032,9 +1032,11 @@ spec:
               serviceAccountName: wlo-controller-manager
               terminationGracePeriodSeconds: 10
               volumes:
-              - emptyDir: {}
+              - emptyDir:
+                  sizeLimit: 20Mi
                 name: scratch
-              - emptyDir: {}
+              - emptyDir:
+                  sizeLimit: 20Mi
                 name: socket
       permissions:
       - rules:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -103,9 +103,11 @@ spec:
             subPath: operator.sock
       volumes:
         - name: scratch
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: 20Mi
         - name: socket
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: 20Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
       affinity:

--- a/internal/deploy/kubectl/websphereliberty-app-operator.yaml
+++ b/internal/deploy/kubectl/websphereliberty-app-operator.yaml
@@ -366,7 +366,9 @@ spec:
       serviceAccountName: wlo-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:
-      - emptyDir: {}
+      - emptyDir:
+          sizeLimit: 20Mi
         name: scratch
-      - emptyDir: {}
+      - emptyDir:
+          sizeLimit: 20Mi
         name: socket

--- a/internal/deploy/kustomize/daily/base/websphere-liberty-deployment.yaml
+++ b/internal/deploy/kustomize/daily/base/websphere-liberty-deployment.yaml
@@ -114,7 +114,9 @@ spec:
       serviceAccountName: websphere-liberty-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:
-      - emptyDir: {}
+      - emptyDir:
+          sizeLimit: 20Mi
         name: scratch
-      - emptyDir: {}
+      - emptyDir:
+          sizeLimit: 20Mi
         name: socket


### PR DESCRIPTION
**What this PR does / why we need it?**:
- To set a size limit on the emptyDir volume

https://github.com/OpenLiberty/open-liberty-operator/issues/772
