### PR TITLE
Update moby package to v28.5.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/WASdev/websphere-liberty-operator
 go 1.25
 
 require (
-	github.com/OpenLiberty/open-liberty-operator v0.8.1-0.20251113001154-53f142458399
+	github.com/OpenLiberty/open-liberty-operator v0.8.1-0.20251119151614-03a2c31300ce
 	github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20251112192657-d3827b10fc11
 	github.com/cert-manager/cert-manager v1.16.5
 	github.com/go-logr/logr v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/OpenLiberty/open-liberty-operator v0.8.1-0.20251113001154-53f142458399 h1:TsIWrvAt0diCgfI3xT4clwEzjIJLOZD+j81NaETuElU=
 github.com/OpenLiberty/open-liberty-operator v0.8.1-0.20251113001154-53f142458399/go.mod h1:AhGx9DV+BbSsptV84qmR0yor2plq4apgrycTUou29rU=
+github.com/OpenLiberty/open-liberty-operator v0.8.1-0.20251119151614-03a2c31300ce h1:CH+6WVq6ZfavKv4gCUzlV7hBbnv5pNPAVKqhAA0d1eo=
+github.com/OpenLiberty/open-liberty-operator v0.8.1-0.20251119151614-03a2c31300ce/go.mod h1:YwjU4zbvbACaaeRwaPWDYPMv5ZaSzuC/YZgKBRpH9ls=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20251112192657-d3827b10fc11 h1:RDvxia2FkqLIuQYgboUdzKXF7Iwunai22FE5QwjCv1o=


### PR DESCRIPTION
- Updates moby package to v28.5.2 and switches over to using `registry.AuthConfig{}`
- **Note**: Requires pulling open-liberty-operator@main after https://github.com/OpenLiberty/open-liberty-operator/pull/799 is merged to match using the same package. 