### PR TITLE
Add passwordEncodingType to Operator ConfigMap for aes-128 fallback

### DIFF
--- a/internal/controller/liberty_security_utility.go
+++ b/internal/controller/liberty_security_utility.go
@@ -28,10 +28,12 @@ const SECURITY_UTILITY_ENCODE = "encode"
 const SECURITY_UTILITY_CREATE_LTPA_KEYS = "createLTPAKeys"
 const SECURITY_UTILITY_OUTPUT_FOLDER = "liberty/output"
 
-func encode(password string, passwordKey *string) ([]byte, error) {
+var validPasswordEncodingTypes = []string{"aes", "aes-128"}
+
+func encode(password string, passwordKey *string, passwordEncodingType string) ([]byte, error) {
 	params := []string{}
 	params = append(params, SECURITY_UTILITY_ENCODE)
-	params = append(params, fmt.Sprintf("--encoding=%s", "aes"))
+	params = append(params, fmt.Sprintf("--encoding=%s", parsePasswordEncodingType(passwordEncodingType)))
 	if passwordKey != nil && len(*passwordKey) > 0 {
 		params = append(params, fmt.Sprintf("--key=%s", *passwordKey))
 	}
@@ -39,7 +41,7 @@ func encode(password string, passwordKey *string) ([]byte, error) {
 	return callSecurityUtility(params)
 }
 
-func createLTPAKeys(password string, passwordKey *string) ([]byte, error) {
+func createLTPAKeys(password string, passwordKey *string, passwordEncodingType string) ([]byte, error) {
 	tmpFileName := fmt.Sprintf("ltpa-keys-%s.keys", utils.GetRandomAlphanumeric(15))
 	tmpFilePath := fmt.Sprintf("%s/%s", SECURITY_UTILITY_OUTPUT_FOLDER, tmpFileName)
 
@@ -53,7 +55,7 @@ func createLTPAKeys(password string, passwordKey *string) ([]byte, error) {
 	params := []string{}
 	params = append(params, SECURITY_UTILITY_CREATE_LTPA_KEYS)
 	params = append(params, fmt.Sprintf("--file=%s", tmpFilePath))
-	params = append(params, fmt.Sprintf("--passwordEncoding=%s", "aes")) // use aes encoding
+	params = append(params, fmt.Sprintf("--passwordEncoding=%s", parsePasswordEncodingType(passwordEncodingType))) // use aes encoding
 	if passwordKey != nil && len(*passwordKey) > 0 {
 		params = append(params, fmt.Sprintf("--passwordKey=%s", *passwordKey))
 	}
@@ -69,6 +71,16 @@ func createLTPAKeys(password string, passwordKey *string) ([]byte, error) {
 	// delete the key
 	callDeleteFile(tmpFilePath)
 	return bytesOut, err
+}
+
+// Returns the password encoding type to use for Liberty security utility encode and createLTPAKeys. Defaults to "aes" when invalid or undefined.
+func parsePasswordEncodingType(passwordEncodingType string) string {
+	for _, validType := range validPasswordEncodingTypes {
+		if validType == passwordEncodingType {
+			return validType
+		}
+	}
+	return "aes"
 }
 
 // func callMkdir(folderPath string) {

--- a/internal/controller/ltpa_keys_sharing.go
+++ b/internal/controller/ltpa_keys_sharing.go
@@ -28,6 +28,7 @@ import (
 	tree "github.com/OpenLiberty/open-liberty-operator/utils/tree"
 	wlv1 "github.com/WASdev/websphere-liberty-operator/api/v1"
 	lutils "github.com/WASdev/websphere-liberty-operator/utils"
+	"github.com/application-stacks/runtime-component-operator/common"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -283,7 +284,7 @@ func (r *ReconcileWebSphereLiberty) generateLTPAKeys(instance *wlv1.WebSphereLib
 		} else {
 			currentPasswordEncryptionKey = nil
 		}
-		rawLTPAKeysStringData, err := createLTPAKeys(password, currentPasswordEncryptionKey)
+		rawLTPAKeysStringData, err := createLTPAKeys(password, currentPasswordEncryptionKey, common.LoadFromConfig(common.Config, lutils.OpConfigPasswordEncodingType))
 		if err != nil {
 			return "", "", "", err
 		}
@@ -449,7 +450,7 @@ func (r *ReconcileWebSphereLiberty) generateLTPAConfig(instance *wlv1.WebSphereL
 			} else {
 				currentPasswordEncryptionKey = nil
 			}
-			encodedPassword, err := encode(password, currentPasswordEncryptionKey)
+			encodedPassword, err := encode(password, currentPasswordEncryptionKey, common.LoadFromConfig(common.Config, lutils.OpConfigPasswordEncodingType))
 			if err != nil {
 				return "", err
 			}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -223,6 +223,7 @@ const (
 	OpConfigPerformanceDataMaxWorkers                = "performanceDataMaxWorkers"
 	OpConfigImageVersionChecks                       = "imageVersionChecks"
 	OpConfigImageVersionChecksRefreshIntervalMinutes = "imageVersionChecksRefreshIntervalMinutes"
+	OpConfigPasswordEncodingType                     = "passwordEncodingType"
 )
 
 var DefaultLibertyOpConfig *sync.Map
@@ -232,6 +233,7 @@ func init() {
 	DefaultLibertyOpConfig.Store(OpConfigPerformanceDataMaxWorkers, "10")
 	DefaultLibertyOpConfig.Store(OpConfigImageVersionChecks, "true")
 	DefaultLibertyOpConfig.Store(OpConfigImageVersionChecksRefreshIntervalMinutes, "720")
+	DefaultLibertyOpConfig.Store(OpConfigPasswordEncodingType, "aes")
 }
 
 func parseFlag(key, value, delimiter string) string {


### PR DESCRIPTION
Adds `.data.passwordEncodingType` to Operator ConfigMap for aes-128 fallback (defaults to `aes`)