### PR TITLE
Ignore secrets baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,5 @@ linter-tool
 bundle/tests
 operators
 liberty/**
+# To allow the file to be copied into this repo during a build
+wlo.secrets.baseline


### PR DESCRIPTION
So that it can be copied into the source tree during a build