### PR TITLE
Update ose-operator-registry to 4.20

### DIFF
--- a/catalog.Dockerfile
+++ b/catalog.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.18 AS builder
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.20 AS builder
 FROM registry.redhat.io/ubi9/ubi-minimal
 
 # Add label for location of Declarative Config root directory & required OpenShift labels


### PR DESCRIPTION
Updating ose-operator-registry-rhel9 from 4.18 to 4.20 in the Catalog dockerfile
Tested against OCP versions

[4.18](https://cloud.ibm.com/devops/pipelines/tekton/b51c61f7-d7fb-49f2-8ff8-9a61e5a4ee18/runs/4469ecb1-49b8-42cc-8fd2-414cefea7b13/ci-start?env_id=ibm:yp:us-south&view=logs)
[4.16](https://cloud.ibm.com/devops/pipelines/tekton/b51c61f7-d7fb-49f2-8ff8-9a61e5a4ee18/runs/7f9ffd7a-1a70-476f-a668-0199c0007c3c/ci-start?env_id=ibm:yp:us-south&view=logs)