### PR TITLE
fix: preserve user-defined `app.kubernetes.io/part-of` label

### DIFF
--- a/api/v1/webspherelibertyapplication_types.go
+++ b/api/v1/webspherelibertyapplication_types.go
@@ -1508,7 +1508,9 @@ func (cr *WebSphereLibertyApplication) Initialize() {
 	}
 
 	if cr.Labels != nil {
-		cr.Labels["app.kubernetes.io/part-of"] = cr.Spec.ApplicationName
+		if _, found := cr.Labels["app.kubernetes.io/part-of"]; !found {
+			cr.Labels["app.kubernetes.io/part-of"] = cr.Spec.ApplicationName
+		}
 	}
 
 	// This is to handle when there is no service in the CR


### PR DESCRIPTION
Previously, the Initialize() method unconditionally overwrote the app.kubernetes.io/part-of label with spec.applicationName, even when users explicitly set a custom value in metadata.labels.

Now checks if the label exists before setting it, respecting user-provided values while still defaulting to spec.applicationName when the label is not present.